### PR TITLE
fix: add which crate to determine location of binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/target
+**/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,6 +2820,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "walkdir",
+ "which",
 ]
 
 [[package]]
@@ -3111,6 +3112,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fd319e971980166b53e17b1026812ad66c6b54063be879eb182342b55284694"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "which"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+dependencies = [
+ "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/toast/Cargo.toml
+++ b/toast/Cargo.toml
@@ -40,6 +40,7 @@ tracing-error = "0.1.2"
 tracing-subscriber = "0.2.12"
 tracing-futures = "0.2.4"
 tracing-attributes = "0.1.11"
+which = "4.0.2"
 
 [dependencies.tracing]
 version = "0.1.19"

--- a/toast/src/main.rs
+++ b/toast/src/main.rs
@@ -21,7 +21,8 @@ const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 #[instrument]
 fn get_npm_bin_dir() -> Result<PathBuf> {
-    let output = Command::new("npm")
+    let npm_path = which::which("npm").expect("failed to get npm path");
+    let output = Command::new(npm_path)
         .arg("bin")
         .output()
         .expect("failed to get npm bin dir");


### PR DESCRIPTION
We can use this to determine the location of npm which will help provide support for any OS.