### PR TITLE
fix: path to import-map.js on windows

### DIFF
--- a/toast/src/main.rs
+++ b/toast/src/main.rs
@@ -104,7 +104,10 @@ fn main() -> Result<()> {
             output_dir,
         } => {
             let import_map = {
-                let import_map_filepath = input_dir.join("public/web_modules/import-map.json");
+                let import_map_filepath = input_dir
+                    .join("public")
+                    .join("web_modules")
+                    .join("import-map.json");
                 let contents = fs::read_to_string(&import_map_filepath).wrap_err_with(|| {
                     format!(
                         "Failed to read `import-map.json` from `{}`",


### PR DESCRIPTION
Manually concating paths breaks on windows assuming posix paths. Chaining multiple  together let's us provide path concats in a cross platform manner.