### PR TITLE
fix: paths to modules and page-wrapper.js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
+name = "dunce"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2641c4a7c0c4101df53ea572bffdc561c146f6c2eb09e4df02bc4811e3feeb4"
+
+[[package]]
 name = "either"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2791,6 +2797,7 @@ dependencies = [
  "async-std",
  "color-eyre",
  "crossbeam",
+ "dunce",
  "futures",
  "owo-colors",
  "salsa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 [[package]]
 name = "ast_node"
 version = "0.7.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "darling",
  "pmutil",
@@ -159,29 +159,16 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.3.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
+checksum = "90f47c78ea98277cb1f5e6f60ba4fc762f5eafe9f6511bc2f7dfd8b75c225650"
 dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "once_cell",
- "vec-arena",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fefeb39da249f4c33af940b779a56723ce45809ef5c54dad84bb538d4ffb6d9e"
-dependencies = [
- "async-executor",
  "async-io",
  "futures-lite",
- "num_cpus",
- "once_cell",
+ "multitask",
+ "parking 1.0.6",
+ "scoped-tls",
+ "waker-fn",
 ]
 
 [[package]]
@@ -202,27 +189,28 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.1.6"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bfd63f6fc8fd2925473a147d3f4d252c712291efdde0d7057b25146563402c"
+checksum = "3ae22a338d28c75b53702b66f77979062cb29675db376d99e451af4fa79dedb3"
 dependencies = [
+ "cfg-if",
  "concurrent-queue",
- "fastrand",
  "futures-lite",
- "log",
- "nb-connect",
+ "libc",
  "once_cell",
- "parking",
+ "parking 2.0.0",
  "polling",
+ "socket2",
  "vec-arena",
- "waker-fn",
+ "wepoll-sys-stjepang",
+ "winapi",
 ]
 
 [[package]]
 name = "async-mutex"
-version = "1.4.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+checksum = "66941c2577c4fa351e4ce5fdde8f86c69b88d623f3b955be1bc7362a23434632"
 dependencies = [
  "event-listener",
 ]
@@ -250,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "async-sse"
-version = "4.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a127da64eb321f5b698a43fb9b976d1e5fc1fd3c2f961322d6cc06ce721b47b"
+checksum = "885fb340b166aff3a3b16dd49ef169d8ee34428aa10c0432c61fff584aa222b9"
 dependencies = [
  "async-channel",
  "async-std",
@@ -264,20 +252,21 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.6.5"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fa76751505e8df1c7a77762f60486f60c71bbd9b8557f4da6ad47d083732ed"
+checksum = "46c8da367da62b8ff2313c406c9ac091c1b31d67a165becdd2de380d846260f7"
 dependencies = [
- "async-global-executor",
+ "async-executor",
  "async-io",
  "async-mutex",
+ "async-task",
  "blocking",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
  "futures-lite",
- "gloo-timers",
+ "futures-timer",
  "kv-log-macro",
  "log",
  "memchr",
@@ -291,15 +280,15 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab27c1aa62945039e44edaeee1dc23c74cc0c303dd5fe0fb462a184f1c3a518"
+checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-trait"
-version = "0.1.41"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -337,9 +326,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.51"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1"
+checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -385,9 +374,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake3"
-version = "0.3.7"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ff35b701f3914bdb8fad3368d822c766ef2858b2583198e41639b936f09d3f"
+checksum = "ce4f9586c9a3151c4b49b19e82ba163dd073614dd057e53c969e1a4db5b52720"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -418,13 +407,12 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.0.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2640778f8053e72c11f621b0a5175a0560a269282aa98ed85107773ab8e2a556"
+checksum = "ea5800d29218fea137b0880387e5948694a23c93fcdde157006966693a865c7c"
 dependencies = [
  "async-channel",
  "atomic-waker",
- "fastrand",
  "futures-lite",
  "once_cell",
  "waker-fn",
@@ -460,9 +448,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.60"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
 
 [[package]]
 name = "cfg-if"
@@ -472,16 +460,14 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
 dependencies = [
- "libc",
  "num-integer",
  "num-traits",
  "serde",
  "time 0.1.44",
- "winapi",
 ]
 
 [[package]]
@@ -519,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.5.5"
+version = "0.5.4-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae3fcb8e4494aaf14ef64a78509215edd4ac824114a679e4c799cd7c07ad2a"
+checksum = "321d2fd2fc45845008655ab8056fae8afb17117ecbb7718d1e908f6add629b55"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -615,7 +601,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.7.3",
  "sha2",
- "time 0.2.22",
+ "time 0.2.18",
  "version_check",
 ]
 
@@ -775,6 +761,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "dtoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
 name = "dunce"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,9 +774,9 @@ checksum = "b2641c4a7c0c4101df53ea572bffdc561c146f6c2eb09e4df02bc4811e3feeb4"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "encode_unicode"
@@ -795,7 +787,7 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 [[package]]
 name = "enum_kind"
 version = "0.2.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -810,16 +802,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 
 [[package]]
-name = "event-listener"
-version = "2.5.1"
+name = "error-chain"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "backtrace",
+ "version_check",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cd41440ae7e4734bbd42302f63eaba892afc93a3912dad84006247f0dedb0e"
 
 [[package]]
 name = "eyre"
-version = "0.6.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c5cb4dc433c59f09df4b4450f649cbfed61e8a3505abe32e4154066439157e"
+checksum = "b0f9683839e579a53258d377fcc0073ca0bf2042ac5e6c60a598069e64403a6d"
 dependencies = [
  "indenter",
  "once_cell",
@@ -873,19 +875,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
-dependencies = [
- "matches",
- "percent-encoding",
-]
-
-[[package]]
 name = "from_variant"
 version = "0.1.2"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -955,15 +947,15 @@ checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-lite"
-version = "1.8.0"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db18c5f58083b54b0c416638ea73066722c2815c1e54dd8ba85ee3def593c3a"
+checksum = "97999970129b808f0ccba93211201d431fcc12d7e1ffae03a61b5cedd1a7ced2"
 dependencies = [
  "fastrand",
  "futures-core",
  "futures-io",
  "memchr",
- "parking",
+ "parking 2.0.0",
  "pin-project-lite",
  "waker-fn",
 ]
@@ -993,6 +985,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
 ]
 
 [[package]]
@@ -1036,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1075,9 +1077,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+dependencies = [
+ "autocfg 1.0.1",
+]
 
 [[package]]
 name = "heck"
@@ -1090,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.16"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
@@ -1119,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "http-types"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e703a631784b7881751ebff731cd645eb4c7f9b6288c19178ba9e1c4788d39"
+checksum = "bb4daf8dc001485f4a32a7a17c54c67fa8a10340188f30ba87ac0fe1a9451e97"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1161,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "if_chain"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7280c75fb2e2fc47080ec80ccc481376923acb04501957fc38f935c3de5088"
+checksum = "c3360c7b59e5ffa2653671fb74b4741a5d343c03f331c0a4aeda42b5c2b0ec7d"
 
 [[package]]
 name = "indenter"
@@ -1173,9 +1178,9 @@ checksum = "e0bd112d44d9d870a6819eb505d04dd92b5e4d94bb8c304924a0872ae7016fb5"
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown",
@@ -1195,18 +1200,15 @@ dependencies = [
 
 [[package]]
 name = "infer"
-version = "0.2.3"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+checksum = "6854dd77ddc4f9ba1a448f487e27843583d407648150426a30c2ea3a2c39490a"
 
 [[package]]
 name = "instant"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
-dependencies = [
- "cfg-if",
-]
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 
 [[package]]
 name = "is-macro"
@@ -1238,8 +1240,8 @@ dependencies = [
 
 [[package]]
 name = "jsdoc"
-version = "0.6.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+version = "0.4.0"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "nom",
  "serde",
@@ -1277,9 +1279,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.78"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
+checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "lock_api"
@@ -1345,31 +1347,31 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
  "autocfg 1.0.1",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
+checksum = "4d7559a8a40d0f97e1edea3220f698f78b1c5ab67532e49f68fde3910323b722"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
 ]
 
 [[package]]
-name = "nb-connect"
-version = "1.0.1"
+name = "multitask"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701f47aeb98466d0a7fea67e2c2f667c33efa1f2e4fd7f76743aac1153196f72"
+checksum = "c09c35271e7dcdb5f709779111f2c8e8ab8e06c1b587c1c6a9e179d865aaa5b4"
 dependencies = [
- "libc",
- "winapi",
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
 ]
 
 [[package]]
@@ -1514,6 +1516,12 @@ checksum = "7a1250cdd103eef6bd542b5ae82989f931fc00a41a27f60377338241594410f3"
 
 [[package]]
 name = "parking"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb300f271742d4a2a66c01b6b2fa0c83dfebd2e0bf11addb879a3547b4ed87c"
+
+[[package]]
+name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
@@ -1583,17 +1591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
-dependencies = [
- "phf_macros",
- "phf_shared 0.8.0",
- "proc-macro-hack",
-]
-
-[[package]]
 name = "phf_generator"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,20 +1598,6 @@ checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
 dependencies = [
  "phf_shared 0.8.0",
  "rand 0.7.3",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
-dependencies = [
- "phf_generator",
- "phf_shared 0.8.0",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1637,18 +1620,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.25"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b9e280448854bd91559252582173b3bd1f8e094a0e644791c0628ca9b1f144f"
+checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.25"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8c8b352676bc6a4c3d71970560b913cea444a7a921cc2e2d920225e4b91edaa"
+checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1657,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.10"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
+checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
 
 [[package]]
 name = "pin-utils"
@@ -1680,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "1.1.0"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0720e0b9ea9d52451cf29d3413ba8a9303f8815d9d9653ef70e03ff73e65566"
+checksum = "8fffa183f6bd5f1a8a3e1f60ce2f8d5621e350eed84a62d6daaa5b9d1aaf6fbd"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1693,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5884790f1ce3553ad55fec37b5aaac5882e0e845a2612df744d6c85c9bf046c"
+checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
 dependencies = [
  "cfg-if",
  "universal-hash",
@@ -1751,9 +1734,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid",
 ]
@@ -2088,19 +2071,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "serde"
-version = "1.0.116"
+name = "send_wrapper"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "serde"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2109,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.58"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
+checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 dependencies = [
  "itoa",
  "ryu",
@@ -2120,26 +2109,26 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9408a61dabe404c76cec504ec510f7d92f41dc0a9362a0db8ab73d141cfbf93f"
+checksum = "c6f3acf84e23ab27c01cb5917551765c01c50b2000089db8fa47fe018a3260cf"
 dependencies = [
  "data-encoding",
+ "error-chain 0.12.4",
  "percent-encoding",
  "serde",
- "thiserror",
 ]
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
- "form_urlencoded",
+ "dtoa",
  "itoa",
- "ryu",
  "serde",
+ "url",
 ]
 
 [[package]]
@@ -2208,6 +2197,18 @@ name = "smallvec"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+
+[[package]]
+name = "socket2"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
 
 [[package]]
 name = "sourcemap"
@@ -2345,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "string_enum"
 version = "0.3.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -2368,9 +2369,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33f6461027d7f08a13715659b2948e1602c31a3756aeae9378bfe7518c72e82"
+checksum = "6cc388d94ffabf39b5ed5fadddc40147cb21e605f53db6f8f36a625d27489ac5"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2379,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.11"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92e775028122a4b3dd55d58f14fc5120289c69bee99df1d117ae30f84b225c9"
+checksum = "5e2513111825077552a6751dfad9e11ce0fba07d7276a3943a037d7e93e64c5f"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2403,7 +2404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55a6a82b25841407b4e9a6831d3cd9dc56c4b88664fea877ed387dcf17c9baf7"
 dependencies = [
  "clap",
- "error-chain",
+ "error-chain 0.11.0",
  "fern",
  "log",
  "svgdom",
@@ -2415,7 +2416,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac5d235d251b4266fb95bdf737fe0c546b26327a127e35ad33effdd78cb2e83"
 dependencies = [
- "error-chain",
+ "error-chain 0.11.0",
  "float-cmp",
  "log",
  "simplecss",
@@ -2428,9 +2429,9 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b2a4d5f7d25526c750e436fb5a224e06579f32581515bf511b37210007a3cb"
 dependencies = [
- "error-chain",
+ "error-chain 0.11.0",
  "log",
- "phf 0.7.24",
+ "phf",
  "xmlparser",
 ]
 
@@ -2440,8 +2441,8 @@ version = "0.1.0"
 
 [[package]]
 name = "swc"
-version = "0.0.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+version = "0.1.0"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "anyhow",
  "base64 0.12.3",
@@ -2457,7 +2458,6 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen",
- "swc_ecma_ext_transforms",
  "swc_ecma_parser",
  "swc_ecma_preset_env",
  "swc_ecma_transforms",
@@ -2467,8 +2467,8 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.2.4"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+version = "0.2.2"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -2476,8 +2476,8 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.10.3"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+version = "0.10.2"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "ast_node",
  "atty",
@@ -2499,8 +2499,8 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.32.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+version = "0.30.0"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "enum_kind",
  "is-macro",
@@ -2513,8 +2513,8 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.36.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+version = "0.34.0"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "bitflags",
  "num-bigint",
@@ -2528,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_codegen_macros"
 version = "0.5.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -2538,23 +2538,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_ext_transforms"
-version = "0.0.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
-dependencies = [
- "phf 0.8.0",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_utils",
- "swc_ecma_visit",
-]
-
-[[package]]
 name = "swc_ecma_parser"
-version = "0.38.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+version = "0.36.2"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "either",
  "enum_kind",
@@ -2574,7 +2560,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_parser_macros"
 version = "0.4.1"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -2586,7 +2572,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_preset_env"
 version = "0.1.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "dashmap",
  "fxhash",
@@ -2606,8 +2592,8 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.24.3"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+version = "0.23.0"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "Inflector",
  "arrayvec",
@@ -2620,7 +2606,6 @@ dependencies = [
  "log",
  "once_cell",
  "ordered-float",
- "phf 0.8.0",
  "regex",
  "retain_mut",
  "scoped-tls",
@@ -2639,8 +2624,8 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_macros"
-version = "0.1.1"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+version = "0.1.0"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -2651,8 +2636,8 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.22.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+version = "0.20.0"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "once_cell",
  "scoped-tls",
@@ -2665,8 +2650,8 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.18.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+version = "0.16.0"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2678,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "swc_macros_common"
 version = "0.3.1"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -2689,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "swc_visit"
 version = "0.2.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -2698,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "swc_visit_macros"
 version = "0.2.0"
-source = "git+https://github.com/swc-project/swc#9879fa59c87d1f54bde7413a9ca49e40ffd65b38"
+source = "git+https://github.com/swc-project/swc#578d64a398d1f41a99e1332933db6f7d5e928df2"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -2710,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2829,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.22"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b7151c9065e80917fbf285d9a5d1432f60db41d170ccafc749a136b41a93af"
+checksum = "12785163ae8a1cbb52a5db39af4a5baabd3fe49f07f76f952f89d7e89e5ce531"
 dependencies = [
  "const_fn",
  "libc",
@@ -2844,9 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+checksum = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
 dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
@@ -2915,12 +2900,11 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
  "cfg-if",
- "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -2938,9 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
 dependencies = [
  "lazy_static",
 ]
@@ -3073,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "vec-arena"
-version = "1.0.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+checksum = "8cb18268690309760d59ee1a9b21132c126ba384f374c59a94db4bc03adeb561"
 
 [[package]]
 name = "vec_map"
@@ -3198,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "wepoll-sys-stjepang"
-version = "1.0.8"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdfbb03f290ca0b27922e8d48a0997b4ceea12df33269b9f75e713311eb178d"
+checksum = "6fd319e971980166b53e17b1026812ad66c6b54063be879eb182342b55284694"
 dependencies = [
  "cc",
 ]
@@ -3252,6 +3236,6 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4fb8cb7e78fcf5055e751eae348c81bba17b6c84c8ed9fc5f6cf60e3e15d4aa"
 dependencies = [
- "error-chain",
+ "error-chain 0.11.0",
  "log",
 ]

--- a/toast-node-wrapper/toast-render.mjs
+++ b/toast-node-wrapper/toast-render.mjs
@@ -29,7 +29,7 @@ async function main() {
     const wrapper = await import(pageWrapperPath);
     pageWrapper = wrapper.default;
   } catch (e) {
-    console.error("no user pagewrapper supplied/n", e);
+    console.error("no user pagewrapper supplied", e);
   }
 
   // render html

--- a/toast-node-wrapper/toast-render.mjs
+++ b/toast-node-wrapper/toast-render.mjs
@@ -24,7 +24,7 @@ async function main() {
     wrapper = await import(pageWrapperPath);
     pageWrapper = wrapper.default;
   } catch (e) {
-    console.log("no user pagewrapper supplied");
+    console.error("no user pagewrapper supplied/n", e);
   }
 
   // TODO: no data for now

--- a/toast-node-wrapper/toast-render.mjs
+++ b/toast-node-wrapper/toast-render.mjs
@@ -1,5 +1,6 @@
 import path from "path";
-import { existsSync, promises as fs } from "fs";
+import { fileURLToPath } from "url";
+import { promises as fs } from "fs";
 import "./src/module-aliases.mjs";
 import { render } from "./src/page-renderer-pre.mjs";
 

--- a/toast-node-wrapper/toast-render.mjs
+++ b/toast-node-wrapper/toast-render.mjs
@@ -11,7 +11,15 @@ main();
 async function main() {
   // require pageWrapper
   let pageWrapper;
-  const pageWrapperPath = path.resolve(srcDir, "src/page-wrapper.js");
+  const pageWrapperPath =
+    "./" +
+    path.posix.join(
+      ...path
+        .relative(path.dirname(fileURLToPath(import.meta.url)), srcDir)
+        .split(path.sep),
+      "src",
+      "page-wrapper.js"
+    );
   try {
     wrapper = await import(pageWrapperPath);
     pageWrapper = wrapper.default;

--- a/toast-node-wrapper/toast-render.mjs
+++ b/toast-node-wrapper/toast-render.mjs
@@ -11,6 +11,10 @@ main();
 async function main() {
   // require pageWrapper
   let pageWrapper;
+  // Imports are expected to be in posix. We receive a full path here through
+  // the import.meta.url, use the srcDir and convert it to posix.
+  // It also can't import if it begins with a drive letter on Windows, so
+  // we find the relative path from this file to the srcDir.
   const pageWrapperPath =
     "./" +
     path.posix.join(

--- a/toast/Cargo.toml
+++ b/toast/Cargo.toml
@@ -41,6 +41,7 @@ tracing-subscriber = "0.2.12"
 tracing-futures = "0.2.4"
 tracing-attributes = "0.1.11"
 which = "4.0.2"
+dunce = "1.0.1"
 
 [dependencies.tracing]
 version = "0.1.19"

--- a/toast/src/cli_args.rs
+++ b/toast/src/cli_args.rs
@@ -6,7 +6,7 @@ use tracing::instrument;
 
 #[instrument]
 fn abspath(input_dir: &str) -> Result<PathBuf> {
-    match PathBuf::from(input_dir).canonicalize() {
+    match dunce::canonicalize(input_dir) {
         Ok(dir) => Ok(dir),
         Err(_err) => Err(eyre!(
             "Could not find directory `{}` for input_dir from {}",

--- a/toast/src/toast/node.rs
+++ b/toast/src/toast/node.rs
@@ -11,10 +11,7 @@ pub fn render_to_html(
     filepaths: Vec<String>,
     npm_bin_dir: PathBuf,
 ) -> Result<()> {
-    let bin = npm_bin_dir
-        .join("..")
-        .join("toastrs")
-        .join("toast-render.mjs");
+    let bin = npm_bin_dir.join("toast-render");
     let mut cmd = Command::new("node");
     let bin_str = bin
         .to_str()
@@ -42,10 +39,7 @@ pub async fn source_data(toast_js_file: &PathBuf, npm_bin_dir: PathBuf) -> Resul
     // goes to look for it: just a sanity check to not
     // execute Command if we don't need to
     if toast_js_file.exists() {
-        let bin = npm_bin_dir
-            .join("..")
-            .join("toastrs")
-            .join("toast-source-data.mjs");
+        let bin = npm_bin_dir.join("toast-source-data");
         let mut cmd = Command::new("node");
         let bin_str = bin
             .to_str()

--- a/toast/src/toast/node.rs
+++ b/toast/src/toast/node.rs
@@ -11,7 +11,10 @@ pub fn render_to_html(
     filepaths: Vec<String>,
     npm_bin_dir: PathBuf,
 ) -> Result<()> {
-    let bin = npm_bin_dir.join("toast-render");
+    let bin = npm_bin_dir
+        .join("..")
+        .join("toastrs")
+        .join("toast-render.mjs");
     let mut cmd = Command::new("node");
     let bin_str = bin
         .to_str()
@@ -38,7 +41,10 @@ pub async fn source_data(toast_js_file: &PathBuf, npm_bin_dir: PathBuf) -> Resul
     // goes to look for it: just a sanity check to not
     // execute Command if we don't need to
     if toast_js_file.exists() {
-        let bin = npm_bin_dir.join("toast-source-data");
+        let bin = npm_bin_dir
+            .join("..")
+            .join("toastrs")
+            .join("toast-source-data.mjs");
         let mut cmd = Command::new("node");
         let bin_str = bin
             .to_str()


### PR DESCRIPTION
First step was to fix paths to find mjs in node_modules/toastrs not routed through the symlink in bin. Windows doesn't have a symlink to BREAKAGES. For the page-wrapper.js, we had to fix both the UNC in windows from `std::fs::canonicalize` and imports can't have an absolute path beginning with C: (the letter drive). So we munge it and convert it to a posix based relative path.