### PR TITLE
fix: check static dir exists before copying

### DIFF
--- a/toast/src/incremental.rs
+++ b/toast/src/incremental.rs
@@ -263,7 +263,9 @@ pub async fn incremental_compile(opts: IncrementalOpts<'_>) -> Result<()> {
     };
     let static_dir = project_root_dir.join("static");
     let public_dir = project_root_dir.join("public");
-    copy(static_dir, public_dir, &options)?;
+    if static_dir.exists() && public_dir.exists() {
+        copy(static_dir, public_dir, &options)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
fixes https://github.com/toastdotdev/toast/issues/6

Now we will check if static dir exists before copying.

I didn't add tests before there is no tests in this project right now.