### PR TITLE
fix: ignore module not found error when reading page wrapper

### DIFF
--- a/toast-node-wrapper/toast-render.mjs
+++ b/toast-node-wrapper/toast-render.mjs
@@ -29,7 +29,9 @@ async function main() {
     const wrapper = await import(pageWrapperPath);
     pageWrapper = wrapper.default;
   } catch (e) {
-    console.error("no user pagewrapper supplied", e);
+    if (e.code !== "ERR_MODULE_NOT_FOUND") {
+      console.error("Error while reading page-wrapper", e);
+    }
   }
 
   // render html


### PR DESCRIPTION
fixes: https://github.com/toastdotdev/toast/issues/12

This PR checks the error code while reading page-wrapper and ignore `MODULE_NOT_FOUND` error. 