### PR TITLE
fix: node_modules path as cli arg

### DIFF
--- a/toast-node-wrapper/binary-management/binary.js
+++ b/toast-node-wrapper/binary-management/binary.js
@@ -142,13 +142,13 @@ class Binary {
     }
   }
 
-  run() {
+  run(extraArgs = []) {
     const binaryPath = this._getBinaryPath();
     const [, , ...args] = process.argv;
 
     const options = { cwd: process.cwd(), stdio: "inherit" };
 
-    const result = spawnSync(binaryPath, args, options);
+    const result = spawnSync(binaryPath, [...args, ...extraArgs], options);
 
     if (result.error) {
       console.error(result.error);
@@ -225,7 +225,11 @@ const getBinary = () => {
 
 export const run = () => {
   const binary = getBinary();
-  binary.run();
+  const toastModules = path.dirname(
+    path.dirname(fileURLToPath(import.meta.url))
+  );
+  const args = ["--toast-module-path", toastModules];
+  binary.run(args);
 };
 
 export const setLocalBinaryPath = (localPath) => {

--- a/toast-node-wrapper/binary-management/binary.js
+++ b/toast-node-wrapper/binary-management/binary.js
@@ -100,7 +100,9 @@ class Binary {
     mkdirSync(this.binaryDirectory, { recursive: true });
 
     if (!this.url.startsWith("http")) {
-      console.log(`Extracting release from ${this.url}`);
+      console.log(
+        `Extracting release from ${this.url} to ${this.binaryDirectory}`
+      );
       tar
         .x({ file: this.url, strip: 1, C: this.binaryDirectory })
         .then(() => {
@@ -112,7 +114,9 @@ class Binary {
           error(`Error extracting release: ${e.message}`, e);
         });
     } else {
-      console.log(`Downloading release from ${this.url}`);
+      console.log(
+        `Downloading release from ${this.url} to ${this.binaryDirectory}`
+      );
 
       return axios({ url: this.url, responseType: "stream" })
         .then((res) => {

--- a/toast/src/cli_args.rs
+++ b/toast/src/cli_args.rs
@@ -27,12 +27,20 @@ pub enum Toast {
         #[structopt(short, long)]
         debug: bool,
 
-        /// Input directory 
+        /// Input directory
         #[structopt(parse(try_from_str = abspath))]
         input_dir: PathBuf,
 
         /// Output directory, "./public" if not present
         #[structopt(parse(from_os_str))]
         output_dir: Option<PathBuf>,
+
+        /// Path to node_modules/toast
+        #[structopt(short, long, parse(try_from_str = abspath))]
+        toast_module_path: Option<PathBuf>,
+
+        /// Path to node_modules bin directory
+        #[structopt(short, long, parse(try_from_str = abspath))]
+        npm_bin_dir: Option<PathBuf>,
     },
 }

--- a/toast/src/incremental.rs
+++ b/toast/src/incremental.rs
@@ -28,6 +28,7 @@ pub struct IncrementalOpts<'a> {
     pub project_root_dir: &'a PathBuf,
     pub output_dir: PathBuf,
     pub npm_bin_dir: PathBuf,
+    pub toast_module_path: Option<PathBuf>,
     pub import_map: ImportMap,
 }
 
@@ -66,6 +67,7 @@ pub async fn incremental_compile(opts: IncrementalOpts<'_>) -> Result<()> {
         project_root_dir,
         output_dir,
         npm_bin_dir,
+        toast_module_path,
         import_map,
     } = opts;
     let tmp_dir = {
@@ -147,6 +149,7 @@ pub async fn incremental_compile(opts: IncrementalOpts<'_>) -> Result<()> {
             project_root_dir: &project_root_dir,
             output_dir: output_dir.clone(),
             npm_bin_dir: npm_bin_dir.clone(),
+            toast_module_path: toast_module_path.clone(),
             import_map: import_map.clone(),
         },
         &mut cache,
@@ -157,8 +160,12 @@ pub async fn incremental_compile(opts: IncrementalOpts<'_>) -> Result<()> {
         .iter()
         .map(|(_, output_file)| output_file.dest.clone())
         .collect::<Vec<String>>();
-    let _data_from_user =
-        source_data(&project_root_dir.join("toast.js"), npm_bin_dir.clone()).await;
+    let _data_from_user = source_data(
+        &project_root_dir.join("toast.js"),
+        toast_module_path.clone(),
+        npm_bin_dir.clone(),
+    )
+    .await;
 
     let _maybe_gone = server.cancel();
     let _result = fs::remove_file("/var/tmp/toaster.sock");
@@ -209,6 +216,7 @@ pub async fn incremental_compile(opts: IncrementalOpts<'_>) -> Result<()> {
                         project_root_dir: &project_root_dir,
                         output_dir: output_dir.clone(),
                         npm_bin_dir: npm_bin_dir.clone(),
+                        toast_module_path: toast_module_path.clone(),
                         import_map: import_map.clone(),
                     },
                     &mut cache,
@@ -246,6 +254,7 @@ pub async fn incremental_compile(opts: IncrementalOpts<'_>) -> Result<()> {
         tmp_dir.into_os_string().into_string().unwrap(),
         output_dir.into_os_string().into_string().unwrap(),
         list,
+        toast_module_path,
         npm_bin_dir,
     )?;
     render_pb.abandon_with_message("html rendered");
@@ -281,6 +290,7 @@ fn compile_src_files(
         project_root_dir,
         output_dir,
         npm_bin_dir,
+        toast_module_path,
         import_map,
     } = opts;
     let files_by_source_id: HashMap<String, OutputFile> =
@@ -333,6 +343,7 @@ fn compile_src_files(
                 project_root_dir: &project_root_dir,
                 output_dir: output_dir.clone(),
                 npm_bin_dir: npm_bin_dir.clone(),
+                toast_module_path: toast_module_path.clone(),
                 import_map: import_map.clone(),
             },
             cache,
@@ -355,6 +366,7 @@ fn compile_js(
         project_root_dir: _,
         output_dir,
         npm_bin_dir: _,
+        toast_module_path: _,
         import_map,
     } = opts;
     let browser_output_file = output_dir.join(Path::new(&output_file.dest));

--- a/toast/src/main.rs
+++ b/toast/src/main.rs
@@ -19,14 +19,18 @@ use toast::breadbox::parse_import_map;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[instrument]
-fn get_npm_bin_dir() -> Result<PathBuf> {
-    let npm_path = which::which("npm").expect("failed to get npm path");
-    let output = Command::new(npm_path)
-        .arg("bin")
-        .output()
-        .expect("failed to get npm bin dir");
-    let possible_path = std::str::from_utf8(&output.stdout)?;
-    Ok(PathBuf::from(possible_path.trim()))
+fn get_npm_bin_dir(manual_path: Option<PathBuf>) -> Result<PathBuf> {
+    if manual_path != None {
+        Ok(manual_path.unwrap())
+    } else {
+        let npm_path = which::which("npm").expect("failed to get npm path");
+        let output = Command::new(npm_path)
+            .arg("bin")
+            .output()
+            .expect("failed to get npm bin dir");
+        let possible_path = std::str::from_utf8(&output.stdout)?;
+        Ok(PathBuf::from(possible_path.trim()))
+    }
 }
 
 #[instrument]
@@ -97,7 +101,6 @@ fn main() -> Result<()> {
     // });
     // event := builder.new_event()
     // event.add_field("key", Value::String("val".to_string())), event.add(data)
-    let npm_bin_dir = get_npm_bin_dir()?;
     let opt = Toast::from_args();
 
     match opt {
@@ -105,6 +108,8 @@ fn main() -> Result<()> {
             debug,
             input_dir,
             output_dir,
+            toast_module_path,
+            npm_bin_dir,
         } => {
             let import_map = {
                 let import_map_filepath = input_dir
@@ -126,6 +131,7 @@ fn main() -> Result<()> {
                 })?
             };
 
+            let npm_bin_dir_with_default = get_npm_bin_dir(npm_bin_dir)?;
             task::block_on(incremental_compile(IncrementalOpts {
                 debug,
                 project_root_dir: &input_dir,
@@ -144,7 +150,8 @@ fn main() -> Result<()> {
                             .wrap_err_with(|| "Failed canonicalize the output directory path")?
                     }
                 },
-                npm_bin_dir,
+                npm_bin_dir: npm_bin_dir_with_default,
+                toast_module_path,
                 import_map,
             }))
         }

--- a/toast/src/toast/node.rs
+++ b/toast/src/toast/node.rs
@@ -9,9 +9,15 @@ pub fn render_to_html(
     dir_of_input_files: String,
     output_dir: String,
     filepaths: Vec<String>,
+    toast_module_path: Option<PathBuf>,
     npm_bin_dir: PathBuf,
 ) -> Result<()> {
-    let bin = npm_bin_dir.join("toast-render");
+    let bin = if toast_module_path.is_some() {
+        toast_module_path.unwrap()
+    } else {
+        npm_bin_dir
+    }
+    .join("toast-render");
     let mut cmd = Command::new("node");
     let bin_str = bin
         .to_str()
@@ -34,12 +40,21 @@ pub fn render_to_html(
 }
 
 #[instrument]
-pub async fn source_data(toast_js_file: &PathBuf, npm_bin_dir: PathBuf) -> Result<()> {
+pub async fn source_data(
+    toast_js_file: &PathBuf,
+    toast_module_path: Option<PathBuf>,
+    npm_bin_dir: PathBuf,
+) -> Result<()> {
     // not a guarantee that toast.js will exist when node
     // goes to look for it: just a sanity check to not
     // execute Command if we don't need to
     if toast_js_file.exists() {
-        let bin = npm_bin_dir.join("toast-source-data");
+        let bin = if toast_module_path.is_some() {
+            toast_module_path.unwrap()
+        } else {
+            npm_bin_dir
+        }
+        .join("toast-source-data");
         let mut cmd = Command::new("node");
         let bin_str = bin
             .to_str()


### PR DESCRIPTION
Node on windows doesn't setup the bins with symbolic links that we can follow by calling the binary. We don't have very great tools in rust space to derive the location of node_modules and the bin. So instead, we grab them in our light node wrapper and pass them in as args.