### PR TITLE
introduce setDataForSlug API to replace createPage

### DIFF
--- a/toast-node-wrapper/toast-source-data.mjs
+++ b/toast-node-wrapper/toast-source-data.mjs
@@ -10,7 +10,7 @@ async function main() {
   const res = await got(`http://unix:${socketPath}:/`);
   if (res.body === "ready" && toast.sourceData) {
     try {
-      await toast.sourceData({ createPage, setData });
+      await toast.sourceData({ setDataForSlug });
     } catch (e) {
       console.error(e);
     }
@@ -20,16 +20,19 @@ async function main() {
 }
 
 // pageArgs is `{module: JSModuleAsString, slug: String, data: {}}`
-const createPage = async (pageArgs) => {
-  await got.post(`http://unix:${socketPath}:/create-page`, {
-    json: pageArgs,
-  });
-  return { ok: true };
-};
-
-// pageArgs is `{slug: String, data: {}}`
-const setData = async (pageArgs) => {
-  await got.post(`http://unix:${socketPath}:/set-data`, {
+const setDataForSlug = async (pageArgs) => {
+  let args = pagesArgs;
+  if (args.component === null) {
+    args.component = {
+      mode: "no-module",
+    };
+  }
+  if (args.wrapper === null) {
+    args.wrapper = {
+      mode: "no-module",
+    };
+  }
+  await got.post(`http://unix:${socketPath}:/set-data-for-slug`, {
     json: pageArgs,
   });
   return { ok: true };

--- a/toast-node-wrapper/toast-source-data.mjs
+++ b/toast-node-wrapper/toast-source-data.mjs
@@ -20,8 +20,93 @@ async function main() {
 }
 
 // pageArgs is `{module: JSModuleAsString, slug: String, data: {}}`
-const setDataForSlug = async (pageArgs) => {
-  let args = pagesArgs;
+const setDataForSlug = async (slug, pageArgs) => {
+  // the slug is the key for everything, it can not be undefined or falsey
+  if (!slug) {
+    throw new Error(
+      `setDataForSlug requires a slug as the first argument. second argument is ${JSON.stringify(
+        pageArgs
+      )}`
+    );
+  }
+  // This `if` is to protect against this faulty input:
+  //
+  // ```js
+  // setDataForSlug('/', {
+  //  component: ""
+  // })
+  // ```
+  //
+  if (typeof pageArgs.component === "string") {
+    throw new Error(`The \`component\` passed to \`setDataForSlug\` was passed as a string for slug \`${slug}\`.
+
+It should be an object with a mode of "filepath" or "source":
+
+\`\`\`
+const page = {
+  component: {
+    mode: "source",
+    value: \`import { h } from preact;
+
+export default props => <div>
+  <h1>Some Code</h1>
+</div>\`
+  }
+}
+\`\`\`
+
+or
+
+\`\`\`
+const page = {
+  component: {
+    mode: "filepath",
+    value: "src/pages/index.js"
+  }
+}
+\`\`\`
+`);
+  }
+
+  // This if is to protect against `mode` being at the top level,
+  // outside of `component` or `wrapper`
+  //
+  // ```js
+  // setDataForSlug('/', {
+  //   mode: "filepath",
+  //   data: {}
+  // })
+  // ```
+  //
+  if (pageArgs.mode) {
+    throw new Error(`\`mode\` was passed as a top-level key to \`setDataForSlug\` for slug '${slug}'.
+
+Did you mean to put it in \`component\` or \`wrapper\` object?
+
+## sample unexpected input:
+
+\`\`\`
+const page = {
+  mode: "filepath",
+  data: {},
+}
+\`\`\`
+
+## sample successful input:
+
+\`\`\`
+const page = {
+  component: {
+    mode: "filepath",
+    value: "src/pages/index.js"
+  },
+  data: {}
+}
+\`\`\`
+`);
+  }
+
+  let args = pageArgs;
   if (args.component === null) {
     args.component = {
       mode: "no-module",
@@ -32,8 +117,21 @@ const setDataForSlug = async (pageArgs) => {
       mode: "no-module",
     };
   }
-  await got.post(`http://unix:${socketPath}:/set-data-for-slug`, {
-    json: pageArgs,
-  });
+  try {
+    await got.post(`http://unix:${socketPath}:/set-data-for-slug`, {
+      json: { slug, ...pageArgs },
+    });
+  } catch (error) {
+    if (error.response.statusCode === 422) {
+      // unprocessable entity, something is wrong with the payload
+      throw new Error(
+        `for slug \`${slug}\`, payload keys [${Object.keys(
+          pageArgs
+        )}] were malformatted`
+      );
+    } else {
+      console.error(error);
+    }
+  }
   return { ok: true };
 };

--- a/toast/src/cli_args.rs
+++ b/toast/src/cli_args.rs
@@ -23,11 +23,10 @@ pub enum Toast {
     #[structopt(name = "incremental")]
     Incremental {
         /// Activate debug mode
-        // short and long flags (-d, --debug) will be deduced from the field's name
         #[structopt(short, long)]
         debug: bool,
 
-        /// Input directory 
+        /// The directory of your Toast site
         #[structopt(parse(try_from_str = abspath))]
         input_dir: PathBuf,
 

--- a/toast/src/incremental.rs
+++ b/toast/src/incremental.rs
@@ -9,7 +9,7 @@ use color_eyre::eyre::{eyre, Result, WrapErr};
 use crossbeam::{unbounded, Sender};
 use fs_extra::dir::{copy, CopyOptions};
 use indicatif::{ProgressBar, ProgressStyle};
-use serde::{Deserialize, Serialize};
+use serde_json::value::Value;
 use std::sync::Arc;
 use std::{
     collections::HashMap,
@@ -20,7 +20,10 @@ use std::{
 use tracing::instrument;
 use walkdir::WalkDir;
 
-use crate::toast::cache::Cache;
+use crate::toast::{
+    cache::Cache,
+    internal_api::{ModuleSpec, SetDataForSlug},
+};
 
 #[derive(Debug)]
 pub struct IncrementalOpts<'a> {
@@ -29,18 +32,6 @@ pub struct IncrementalOpts<'a> {
     pub output_dir: PathBuf,
     pub npm_bin_dir: PathBuf,
     pub import_map: ImportMap,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct CreatePage {
-    module: String,
-    slug: String,
-    data: serde_json::Value,
-}
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct SetData {
-    slug: String,
-    data: serde_json::Value,
 }
 
 #[derive(Debug)]
@@ -56,7 +47,7 @@ struct TideSharedState {
 }
 #[derive(Debug, Clone)]
 enum Event {
-    CreatePage(CreatePage),
+    Set(SetDataForSlug),
 }
 
 #[instrument]
@@ -104,33 +95,17 @@ pub async fn incremental_compile(opts: IncrementalOpts<'_>) -> Result<()> {
     });
     let sock = format!("http+unix://{}", "/var/tmp/toaster.sock");
     app.at("/").get(|_| async { Ok("ready") });
-    app.at("/create-page")
+    app.at("/set-data-for-page")
         .post(|mut req: tide::Request<TideSharedState>| async move {
-            let create_page: CreatePage = req.body_json().await?;
+            let mut data: SetDataForSlug = req.body_json().await?;
             req.state()
                 .create_page_progress_bar
-                .set_message(create_page.slug.as_str());
+                .set_message(data.slug.as_str());
             req.state().create_page_progress_bar.inc(1);
 
-            req.state().tx.send(Event::CreatePage(create_page))?;
-            // println!("{:?}", create_page);
-            Ok("ok")
-        });
-    app.at("/set-data")
-        .post(|mut req: tide::Request<TideSharedState>| async move {
-            let mut set_data: SetData = req.body_json().await?;
-            if set_data.slug.ends_with('/') {
-                set_data.slug = format!("{}index", set_data.slug);
-            }
-            let mut json_path = req
-                .state()
-                .output_dir
-                .join(set_data.slug.trim_start_matches('/'));
+            data.normalize();
 
-            json_path.set_extension("json");
-            async_std::fs::create_dir_all(&json_path.parent().unwrap()).await?;
-            async_std::fs::write(json_path, set_data.data.to_string()).await?;
-            // &req.state().tx.send(Event::SetData(set_data))?;
+            req.state().tx.send(Event::Set(data))?;
             Ok("ok")
         });
     app.at("/terminate").get(|_| async {
@@ -165,24 +140,6 @@ pub async fn incremental_compile(opts: IncrementalOpts<'_>) -> Result<()> {
     create_pages_pb.abandon_with_message("pages created");
 
     let v: Vec<Event> = rx.try_iter().collect();
-    for x in v.clone() {
-        match x {
-            Event::CreatePage(CreatePage { module, data, slug }) => {
-                cache.set_source(
-                    &slug,
-                    Source {
-                        source: module,
-                        kind: SourceKind::Raw,
-                    },
-                );
-                let mut json_path = output_dir.join(slug);
-                json_path.set_extension("json");
-                std::fs::create_dir_all(&json_path.parent().unwrap())?;
-                fs::write(json_path, data.to_string())?
-            }
-        };
-    }
-
     let event_len: u64 = v.len() as u64;
     let compile_pb = Arc::new(ProgressBar::new_spinner());
     compile_pb.enable_steady_tick(120);
@@ -196,34 +153,90 @@ pub async fn incremental_compile(opts: IncrementalOpts<'_>) -> Result<()> {
     );
     compile_pb.set_message("compiling...");
     compile_pb.tick();
+
     for x in v.clone() {
         match x {
-            Event::CreatePage(CreatePage { slug, .. }) => {
+            Event::Set(set) => {
                 compile_pb.inc(1);
-                compile_pb.set_message(slug.as_str());
-                compile_js(
-                    &slug,
-                    &OutputFile {
-                        dest: format!("{}.js", slug.trim_matches('/')),
-                    },
-                    IncrementalOpts {
-                        debug,
-                        project_root_dir: &project_root_dir,
-                        output_dir: output_dir.clone(),
-                        npm_bin_dir: npm_bin_dir.clone(),
-                        import_map: import_map.clone(),
-                    },
-                    &mut cache,
-                    &tmp_dir,
-                )?;
+                compile_pb.set_message(set.slug.as_str());
+                let slug_filepath = set.slug_as_relative_filepath();
+                let mut output_path_js = set.slug_as_relative_filepath();
+                output_path_js.set_extension(".js");
+
+                // if there is a component, set the source in the incremental cache
+                // if it's a filepath, we need to figure out how to handle it. I think
+                // that we just need to make sure the filepaths are relative to the project
+                // root so that the incremental cache ids for the sources line up when
+                // we go to render it out or whatnot
+                match &set.component {
+                    None => {}
+                    Some(ModuleSpec::NoModule) => {
+                        panic!("no-module is not implemented for components yet")
+                    }
+                    Some(ModuleSpec::File { path: _ }) => {
+                        panic!("Filepaths are not implemented yet")
+                    }
+                    Some(ModuleSpec::Source { code }) => {
+                        cache.set_source(
+                            &set.slug,
+                            Source {
+                                source: code.to_string(),
+                                kind: SourceKind::Raw,
+                            },
+                        );
+                        compile_js(
+                            &set.slug,
+                            &OutputFile {
+                                dest: output_path_js.display().to_string(),
+                            },
+                            IncrementalOpts {
+                                debug,
+                                project_root_dir: &project_root_dir,
+                                output_dir: output_dir.clone(),
+                                npm_bin_dir: npm_bin_dir.clone(),
+                                import_map: import_map.clone(),
+                            },
+                            &mut cache,
+                            &tmp_dir,
+                        )?;
+                    }
+                }
+                match &set.data {
+                    Some(Value::Null) => {
+                        // if null, do nothing for now. In the future null
+                        // will cause us to overlay a tombstone on this layer
+                        // similar to an overlay filesystem, resulting in no data
+                        // for the page.
+                    }
+                    Some(v) => {
+                        // we write the files out to disk here today,
+                        // we should probably put them in the incremental cache first
+                        // so that files can depend on them via derived queries
+                        let mut json_path = output_dir.join(slug_filepath);
+                        json_path.set_extension("json");
+                        std::fs::create_dir_all(&json_path.parent().unwrap())?;
+                        fs::write(json_path, v.to_string())?
+                    }
+                    None => {}
+                }
+                match &set.wrapper {
+                    Some(_) => {
+                        panic!("set.wrapper is not implemented yet");
+                    }
+                    None => {}
+                }
             }
-        }
+        };
     }
-    compile_pb.abandon_with_message("sources compiled");
+    compile_pb.abandon_with_message("remote sources compiled");
 
     let remote_file_list: Vec<String> = v
         .iter()
-        .map(|Event::CreatePage(CreatePage { slug, .. })| format!("{}.js", slug.trim_matches('/')))
+        .map(|Event::Set(set)| {
+            let mut js_filepath = set.slug_as_relative_filepath();
+            js_filepath.set_extension("js");
+            js_filepath.display().to_string()
+        })
         .collect();
     let mut list: Vec<String> = file_list
         .clone()

--- a/toast/src/toast.rs
+++ b/toast/src/toast.rs
@@ -11,3 +11,5 @@ pub mod swc_import_map_rewrite;
 pub mod breadbox;
 
 pub mod sources;
+
+pub mod internal_api;

--- a/toast/src/toast/internal_api.rs
+++ b/toast/src/toast/internal_api.rs
@@ -50,14 +50,14 @@ impl SetDataForSlug {
         }
     }
     pub fn slug_as_relative_filepath(&self) -> PathBuf {
-        let s = self.slug.trim_start_matches('/');
-        let mut buf = PathBuf::from(s);
+        let s = if self.slug.ends_with('/') {
+            let t = self.slug.trim_start_matches('/');
+            format!("{}index", t)
+        } else {
+            self.slug.trim_start_matches('/').to_string()
+        };
 
-        if s.ends_with('/') {
-            buf = buf.join("index");
-        }
-
-        buf
+        PathBuf::from(s)
     }
 }
 
@@ -168,6 +168,18 @@ mod tests {
             set.slug_as_relative_filepath(),
             PathBuf::from("something/here/index")
         );
+        Ok(())
+    }
+    #[test]
+    fn test_file_paths_from_root_slug() -> Result<()> {
+        let set = SetDataForSlug {
+            slug: String::from("/"),
+            component: None,
+            data: None,
+            wrapper: None,
+        };
+
+        assert_eq!(set.slug_as_relative_filepath(), PathBuf::from("index"));
         Ok(())
     }
 }

--- a/toast/src/toast/internal_api.rs
+++ b/toast/src/toast/internal_api.rs
@@ -1,0 +1,173 @@
+use serde::{Deserialize, Serialize};
+use serde_json::value::Value;
+use std::path::PathBuf;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "mode")]
+pub enum ModuleSpec {
+    // users should see this as `component: null`
+    #[serde(alias = "no-module")]
+    NoModule,
+    #[serde(alias = "filepath")]
+    File {
+        #[serde(alias = "value")]
+        path: PathBuf,
+    },
+    #[serde(alias = "source")]
+    Source {
+        #[serde(alias = "value")]
+        code: String,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct SetDataForSlug {
+    /// /some/url or some/url
+    pub slug: String,
+    pub component: Option<ModuleSpec>,
+    pub data: Option<serde_json::Value>,
+    pub wrapper: Option<ModuleSpec>,
+}
+
+impl SetDataForSlug {
+    pub fn normalize(&mut self) {
+        // all paths are absolute paths
+        if !self.slug.starts_with('/') {
+            self.slug = "/".to_owned() + &self.slug;
+        }
+        match &self.data {
+            // object with 0 keys is an empty object and shouldn't result
+            // in the creation of a file on disk, and shouldn't blow away
+            // any other data
+            Some(Value::Object(v)) => {
+                if v.len() > 0 {
+                    // Some(Value::Object(v));
+                } else {
+                    self.data = None;
+                }
+            }
+            _ => {}
+        }
+    }
+    pub fn slug_as_relative_filepath(&self) -> PathBuf {
+        let s = self.slug.trim_start_matches('/');
+        let mut buf = PathBuf::from(s);
+
+        if s.ends_with('/') {
+            buf = buf.join("index");
+        }
+
+        buf
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Result, Value};
+
+    #[test]
+    fn test_deserialize_all() -> Result<()> {
+        let data = r#"
+        {
+            "slug": "/something",
+            "component": {
+                "mode": "source",
+                "value": "import { h } from 'preact'; export default props => <div>hi</div>"
+            },
+            "data": {
+                "some": "thing"
+            },
+            "wrapper": {
+                "mode": "filepath",
+                "value": "./some/where.js"
+            }
+        }"#;
+
+        // Parse the string of data into serde_json::Value.
+        let v: Value = serde_json::from_str(data)?;
+
+        // Access parts of the data by indexing with square brackets.
+        let u: SetDataForSlug = serde_json::from_value(v).unwrap();
+        assert_eq!(
+            SetDataForSlug {
+                slug: String::from("/something"),
+                component: Some(ModuleSpec::Source {
+                    code: String::from(
+                        "import { h } from 'preact'; export default props => <div>hi</div>"
+                    )
+                }),
+                data: Some(json!({
+                    "some": "thing"
+                })),
+                wrapper: Some(ModuleSpec::File {
+                    path: [".", "some", "where.js"].iter().collect::<PathBuf>()
+                })
+            },
+            u
+        );
+        Ok(())
+    }
+    #[test]
+    fn test_deserialize_without_data_and_wrapper() -> Result<()> {
+        let data = r#"
+        {
+            "slug": "/something",
+            "component": {
+                "mode": "source",
+                "value": "import { h } from 'preact'; export default props => <div>hi</div>"
+            }
+        }"#;
+
+        // Parse the string of data into serde_json::Value.
+        let v: Value = serde_json::from_str(data)?;
+
+        // Access parts of the data by indexing with square brackets.
+        let u: SetDataForSlug = serde_json::from_value(v).unwrap();
+        assert_eq!(
+            SetDataForSlug {
+                slug: String::from("/something"),
+                component: Some(ModuleSpec::Source {
+                    code: String::from(
+                        "import { h } from 'preact'; export default props => <div>hi</div>"
+                    )
+                }),
+                data: None,
+                wrapper: None
+            },
+            u
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_file_paths_from_slugs() -> Result<()> {
+        let set = SetDataForSlug {
+            slug: String::from("/something/here"),
+            component: None,
+            data: None,
+            wrapper: None,
+        };
+
+        assert_eq!(
+            set.slug_as_relative_filepath(),
+            PathBuf::from("something/here")
+        );
+        Ok(())
+    }
+    #[test]
+    fn test_file_paths_from_slug_directories() -> Result<()> {
+        let set = SetDataForSlug {
+            slug: String::from("/something/here/"),
+            component: None,
+            data: None,
+            wrapper: None,
+        };
+
+        assert_eq!(
+            set.slug_as_relative_filepath(),
+            PathBuf::from("something/here/index")
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
closes #29 and #31 , see those for more details. This renames the new overloaded `createPage` to `setDataForSlug`. It is a breaking change in the API.

Also adds new unit tests for the url to filepath handling