### PR TITLE
chore: output file list in integration test and switch deploy to npx

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -57,7 +57,7 @@ jobs:
         working-directory: www.toast.dev
         run: cp -r ./../toast/toast-node-wrapper ./node_modules/toast
         shell: bash
-      - name: posinstall on toast.dev
+      - name: postinstall on toast.dev
         working-directory: www.toast.dev
         run: npm run postinstall
       - name: npm install in toast node wrapper

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -69,10 +69,14 @@ jobs:
       - name: toast incremental
         working-directory: www.toast.dev
         run: npm run build
+      - name: display files
+        working-directory: www.toast.dev/public
+        run: ls -R
+        shell: bash
       - name: deploy
         working-directory: www.toast.dev
         if: github.event.ref == 'refs/heads/main'
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_WWW_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        run: netlify deploy --dir=public --message ${{ github.event.head_commit.url }}
+        run: npx netlify-cli deploy --dir=public --message ${{ github.event.head_commit.url }}


### PR DESCRIPTION
The netlify deploy step fails on Mac and Windows as that image does not have netlify cli installed. Use npx on all three platforms to keep it simple.