### PR TITLE
Use output dir for input map location

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -73,16 +73,6 @@ jobs:
         working-directory: www.toast.dev/public
         run: ls -R
         shell: bash
-        - name: postinstall on toast.dev for different output dir
-        working-directory: www.toast.dev
-        run: npm run postinstall --dest dist
-        name: toast incremental different output dir
-        working-directory: www.toast.dev
-        run: npm run build --dest dist
-      - name: display files in dist
-        working-directory: www.toast.dev/dist
-        run: ls -R
-        shell: bash
       - name: deploy
         working-directory: www.toast.dev
         if: github.event.ref == 'refs/heads/main'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -73,6 +73,16 @@ jobs:
         working-directory: www.toast.dev/public
         run: ls -R
         shell: bash
+        - name: postinstall on toast.dev for different output dir
+        working-directory: www.toast.dev
+        run: npm run postinstall --dest dist
+        name: toast incremental different output dir
+        working-directory: www.toast.dev
+        run: npm run build --dest dist
+      - name: display files in dist
+        working-directory: www.toast.dev/dist
+        run: ls -R
+        shell: bash
       - name: deploy
         working-directory: www.toast.dev
         if: github.event.ref == 'refs/heads/main'

--- a/toast/src/main.rs
+++ b/toast/src/main.rs
@@ -107,8 +107,8 @@ fn main() -> Result<()> {
             output_dir,
         } => {
             let import_map = {
-                let import_map_filepath = input_dir
-                    .join("public")
+                let import_map_filepath = output_dir.clone()
+                    .unwrap_or(input_dir.join("public"))
                     .join("web_modules")
                     .join("import-map.json");
                 let contents = fs::read_to_string(&import_map_filepath).wrap_err_with(|| {


### PR DESCRIPTION
Updates the import map path to use `output-dir/web_modules` if an output dir argument is provided. If one isn't provided, fallback to `public/web_modules`

Also adds a series of steps to the integration tests that build www to a separate directory. 