### PR TITLE
Add local dev instructions to readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,10 @@ Copy-Item 'target\debug\toast.exe' $(node .\toast-node-wrapper\binary-management
 Once you've installed the binary, you should be able to run Toast. You can build the `test-toast-site` by running 
 `yarn workspace test-toast-site toast incremental . ` This site is pretty bare-bones, and only has one page to generate. But it can at least tell you that your changes are working.  
 
+
+### Reverting to using a released binary
+When you've finished working on and testing your local binary, you will probably want to revert to using a release binary. To do that, you'll want to delete the binary from the path printed when you run `yarn workspace toast printBinaryPath`. You'll then want to delete your node_modules and reinstall them. This should replace
+
 ## What counts as a contribution?
 
 There are plenty of [open issues][issues] that may fit your skills and expertise. We also highly value documentation changes, user feedback on issues, and more. Code commits are not the only way to contribute. You may also wish to check out the [www.toast.dev issues](https://github.com/toastdotdev/www.toast.dev/issues).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,61 @@ rustc --version
 cargo --version
 ```
 
+## Building the Rust binary
+While making changes to the Rust files, it's helpful to build the project as you go. You can do that by running the following command at the root of the repo: 
+
+```bash
+cargo build
+```
+## Running the binary locally
+It can be useful to test out your changes locally by building a Toast site. However, the way Toast works, you can't just build and run the binary directly. Instead, you'll need to put your binary where the Node wrapper expects the binary to be. If you're on an operating system that supports Make, you can use Make to build and copy the binary to the correct directory. Otherwise, you'll need to copy the file manually. 
+**Note** that all installs of Toast look for the binary in the same location. You'll want to replace the binary if you don't want to use your local build when working on your own Toast sites. 
+
+### Using Make to install the binary
+If you can use Make, you can build the debug version of the binary (same type as cargo build) and copy it to the appropriate destination by running 
+```bash
+make build-debug-install
+```
+If you need to test the performance of your changes, you can instead install the production binary by running 
+```bash
+make build-production-install
+```
+### Installing the binary manually
+If you can't use Make, you can manually install the binary. First, build the binary by running 
+```bash
+cargo build
+# if you need the production build, add --release to the end
+```
+This will build the binary out to either `target/debug/toast` (if you didn't pass the `--release` flag) or `target/rls/toast` (if you did). 
+
+Then, you need to find out where the binary needs to be placed for Toast to run it. To do that, you can run 
+
+```bash
+yarn workspace toast printBinaryPath
+```
+This will print the global path to the Toast binary. You can then copy your binary from the above path to that location. For a more streamlined process, you could run one of the following sets of commands: 
+
+```bash
+# bash
+# get directory to install binary to
+installDir=$(node ./toast-node-wrapper/binary-management/printInstallDirectory.js) 
+# if the install directory doesn't exist, make it
+[ -d $installDir ] || mkdir -p $installDir
+# copy the binary to the appropriate place
+cp target/debug/toast $(node './toast-node-wrapper/binary-management/printBinaryPath')
+```
+```powershell
+# powershell
+# if install directory doesn't exist, make it
+if ( -not (Test-Path $(node '.\toast-node-wrapper\binary-management\printInstallDirectory.js'))) {mkdir node '.\toast-node-wrapper\binary-management\printInstallDirectory.js'}
+Copy-Item 'target\debug\toast.exe' $(node .\toast-node-wrapper\binary-management\printBinaryPath)
+```
+Once you've installed the binary, you should be able to run Toast. You can build the `test-toast-site` by running 
+`yarn workspace test-toast-site toast incremental . ` This site is pretty bare-bones, and only has one page to generate. But it can at least tell you that your changes are working.  
+
 ## What counts as a contribution?
 
-There are plenty of [open issues][issues] that may fit your skills and expertise. We also highly value documentation changes, user feedback on issues, and more. Code commits are not the only way to contribute. You may also wish to check out the [www.toast.dev issues](https://github.com/toastdotdev/toast/issues).
+There are plenty of [open issues][issues] that may fit your skills and expertise. We also highly value documentation changes, user feedback on issues, and more. Code commits are not the only way to contribute. You may also wish to check out the [www.toast.dev issues](https://github.com/toastdotdev/www.toast.dev/issues).
 
 [issues]: https://github.com/toastdotdev/toast/issues
 [www-issues]: https://github.com/toastdotdev/www.toast.dev/issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Once you've installed the binary, you should be able to run Toast. You can build
 
 
 ### Reverting to using a released binary
-When you've finished working on and testing your local binary, you will probably want to revert to using a release binary. To do that, you'll want to delete the binary from the path printed when you run `yarn workspace toast printBinaryPath`. You'll then want to delete your node_modules and reinstall them. This should replace
+When you've finished working on and testing your local binary, you will probably want to revert to using a release binary. To do that, you'll want to delete the binary from the path printed when you run `yarn workspace toast printBinaryPath`. You'll then want to delete your node_modules and reinstall them. This should replace your binary with the version that matches your Toast version. 
 
 ## What counts as a contribution?
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,22 @@
 build-debug:
 	rustup run nightly cargo build 
 	cp ./target/debug/toast ./toast-node-wrapper/
+build-debug-install: build-debug install-locally
 build-production:
 	rustup run nightly cargo build --release
 	cp ./target/release/toast ./toast-node-wrapper/
+build-production-install: build-production install-locally
+
 copy-linux-toast:
 	docker build -t temprust .
 	container := $(docker create temprust)
 	docker create ${container}
 	docker cp ${container}:/opt/app/target .
+
+
+installDir = $(shell /usr/bin/env node ./toast-node-wrapper/binary-management/printInstallDirectory.js);
+install-locally: 
+	#if the installDir doesn't exist, make it
+	[ -d '$(installDir)' ] || mkdir -p $(installDir)
+	node ./toast-node-wrapper/binary-management/printBinaryPath.js
+	cp ./toast-node-wrapper/toast $(shell /usr/bin/env node ./toast-node-wrapper/binary-management/printBinaryPath.js)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 ![toast header](./imgs/toast-header.png)
+
+## Interested in contributing?
+If you want to contribute to Toast, checkout the [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/test-toast-site/package.json
+++ b/test-toast-site/package.json
@@ -8,5 +8,16 @@
   "dependencies": {
     "@sector/breadbox": "^0.0.4",
     "toast": "*"
+  },
+  "type": "module",
+  "snowpack": {
+    "exclude": [
+      "postcss.js",
+      "utils/postcss-config-functions.mjs"
+    ],
+    "knownEntrypoints": [
+      "preact",
+      "preact/hooks"
+    ]
   }
 }

--- a/toast-node-wrapper/binary-management/binary.js
+++ b/toast-node-wrapper/binary-management/binary.js
@@ -242,5 +242,10 @@ export const uninstall = () => {
 
 export const printBinaryPath = () => {
   const binary = getBinary();
-  console.log(path.join(binary.installDirectory, "bin", "toast"))
+  console.log(path.join(binary._getInstallDirectory(), "bin", "toast"))
+}
+
+export const printInstallDirectory = () => {
+  const binary = getBinary();
+  console.log(path.join(binary._getInstallDirectory(), "bin"))
 }

--- a/toast-node-wrapper/binary-management/binary.js
+++ b/toast-node-wrapper/binary-management/binary.js
@@ -242,5 +242,5 @@ export const uninstall = () => {
 
 export const printBinaryPath = () => {
   const binary = getBinary();
-  console.log(binary._getBinaryPath())
+  console.log(path.join(binary.installDirectory, "bin"))
 }

--- a/toast-node-wrapper/binary-management/binary.js
+++ b/toast-node-wrapper/binary-management/binary.js
@@ -239,3 +239,8 @@ export const uninstall = () => {
   const binary = getBinary();
   binary.uninstall();
 };
+
+export const printBinaryPath = () => {
+  const binary = getBinary();
+  console.log(binary._getBinaryPath())
+}

--- a/toast-node-wrapper/binary-management/binary.js
+++ b/toast-node-wrapper/binary-management/binary.js
@@ -242,5 +242,5 @@ export const uninstall = () => {
 
 export const printBinaryPath = () => {
   const binary = getBinary();
-  console.log(path.join(binary.installDirectory, "bin"))
+  console.log(path.join(binary.installDirectory, "bin", "toast"))
 }

--- a/toast-node-wrapper/binary-management/printBinaryPath.js
+++ b/toast-node-wrapper/binary-management/printBinaryPath.js
@@ -1,0 +1,3 @@
+import {printBinaryPath} from "./binary.js";
+
+printBinaryPath();

--- a/toast-node-wrapper/binary-management/printInstallDirectory.js
+++ b/toast-node-wrapper/binary-management/printInstallDirectory.js
@@ -1,0 +1,3 @@
+import {printInstallDirectory} from './binary.js'
+
+printInstallDirectory();

--- a/toast-node-wrapper/package.json
+++ b/toast-node-wrapper/package.json
@@ -16,7 +16,8 @@
   "binaryHash": "<binaryhash>",
   "scripts": {
     "postinstall": "node ./binary-management/install.js",
-    "preuninstall": "node ./binary-management/uninstall.js"
+    "preuninstall": "node ./binary-management/uninstall.js",
+    "printBinaryPath": "node ./binary-management/printBinaryPath.js"
   },
   "files": [
     "toast",

--- a/toast/src/incremental.rs
+++ b/toast/src/incremental.rs
@@ -132,7 +132,7 @@ pub async fn incremental_compile(opts: IncrementalOpts<'_>) -> Result<()> {
         .iter()
         .map(|(_, output_file)| output_file.dest.clone())
         .collect::<Vec<String>>();
-    let data_from_user = source_data(
+    let _data_from_user = source_data(
         &project_root_dir.join("toast.js"),
         npm_bin_dir.clone(),
         create_pages_pb.clone(),


### PR DESCRIPTION
This PR adds instructions to and ergonomics to help devs get setup running their locally built Toast binary. 

- Adds instructions for installing a locally built binary in the appropriate location
- Adds commands to build and install the binary to the Makefile
- Adds functions for printing the directory the binary gets installed to, and the path to the binary
- Adds snowpack config and `type: module` to test-toast-site so it can run without incident.