### PR TITLE
new binary handling

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -49,11 +49,11 @@ jobs:
           npx create-toast default
           cd default
           node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; delete json.scripts.postinstall; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
-          npm i
+          yarn
           ls -R node_modules/toast
           ls -R node_modules/preact
-          npm run breadbox --dest public/web_modules
-          npm run build
+          yarn breadbox --dest public/web_modules
+          yarn build
         shell: bash
         env:
           TOAST_PREVENT_INSTALL: true

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,8 +48,8 @@ jobs:
       - name: replace toast dep with local toast-node-wrapper
         working-directory: www.toast.dev
         run: |
-          sed -i "s/^\s*\"toast\":.*\(,?\)$/  \"toast\": \"..\/toast\/toast-node-wrapper\"\1/" package.json
-        - name: npm install in toast.dev
+          sed -i "s/^\s*\"toast\":.*(,?)$/  \"toast\": \"..\/toast\/toast-node-wrapper\"\1/" package.json
+      - name: npm install in toast.dev
         working-directory: www.toast.dev
         run: npm ci
         env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: replace toast dep with local toast-node-wrapper
         working-directory: starters
         run: |
-          for D in `find . -t d -d 1`
+          for D in `fd . -t d -d 1`
           do
             cd $D;
             echo $D;

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -66,7 +66,7 @@ jobs:
           done
         shell: bash
         env:
-          TOAST_BINARY: ../../toast/target/debug/toast
+          TOAST_PREVENT_INSTALL: true
       # - name: deploy
       #   working-directory: www.toast.dev
       #   if: github.event.ref == 'refs/heads/main'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run cargo build
         working-directory: toast
         run: cargo build
-        - name: replace toast dep with local toast-node-wrapper
+      - name: replace toast dep with local toast-node-wrapper
         working-directory: starters
         run: |
           for D in `find . -t d -d 1`

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -57,8 +57,9 @@ jobs:
             echo $D;
             node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
             cat package.json;
-            echo "preinstall"
-            npm i;
+            echo "\npreinstall\n"
+            npm install;
+            echo "\npost npm i\n"
             npm run build;
             echo "post-build"
             ls -R public;

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: replace toast dep with local toast-node-wrapper
         working-directory: www.toast.dev
         run: |
-          sed -i "s/^\s*\"toast\":.*(,?)$/  \"toast\": \"..\/toast\/toast-node-wrapper\"\1/" package.json
+          sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"..\/toast\/toast-node-wrapper\"/" package.json
       - name: npm install in toast.dev
         working-directory: www.toast.dev
         run: npm ci

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -52,7 +52,7 @@ jobs:
           npx create-toast minimal minimal
       - name: starters — Install dependencies
         run: |
-          for D in `fd starters -t d -d 1`
+          for D in `fd . 'starters/' -t d -d 1`
           do
             echo $D;
             ls;
@@ -66,7 +66,7 @@ jobs:
           TOAST_PREVENT_INSTALL: true
       - name: build starters
         run: |
-          for D in `fd starters -t d -d 1`
+          for D in `fd . 'starters/' -t d -d 1`
           do
             cd $D;
             TOAST_BINARY="$PWD/../../toast/target/debug/$BINARY_NAME" yarn build;

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -57,6 +57,7 @@ jobs:
             echo $D;
             node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
             cat package.json;
+            ls -R;
             echo "\npreinstall\n"
             npm install;
             echo "\npost npm i\n"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -45,10 +45,13 @@ jobs:
       - name: Run cargo build
         working-directory: toast
         run: cargo build
+      - name: Install fd
+        run: |
+          sudo apt install fd-find
       - name: replace toast dep with local toast-node-wrapper
         working-directory: starters
         run: |
-          for D in `find . -d 1`
+          for D in `find . -t d -d 1`
           do
             cd $D;
             echo $D;

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -50,7 +50,8 @@ jobs:
           cd default
           node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; delete json.scripts.postinstall; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
           npm i
-          ls -R
+          ls -R node_modules/toast
+          ls -R node_modules/preact
           npm run breadbox --dest public/web_modules
           npm run build
         shell: bash

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -29,10 +29,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: toast
-      - uses: actions/checkout@v2
-        with:
-          repository: toastdotdev/starters
-          path: starters
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -42,33 +38,45 @@ jobs:
         with:
           node-version: "14"
           check-latest: true
-      - name: Run cargo build
-        working-directory: toast
-        run: cargo build
-      - name: Install fd
+      # - name: Run cargo build
+      #   working-directory: toast
+      #   run: cargo build
+      # - name: Install fd
+      #   run: |
+      #     cargo install fd-find
+      - name: starter
         run: |
-          cargo install fd-find
-      - name: replace toast dep with local toast-node-wrapper
-        working-directory: starters
-        run: |
-          for D in `fd . -t d -d 1`
-          do
-            cd $D;
-            echo $D;
-            node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
-            cat package.json;
-            ls -R;
-            echo "\npreinstall\n"
-            npm install;
-            echo "\npost npm i\n"
-            npm run build;
-            echo "post-build"
-            ls -R public;
-            cd -;
-          done
+          npx create-toast default
+          cd default
+          node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; delete json.scripts.postinstall; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
+          npm i
+          ls -R
+          npm run breadbox --dest public/web_modules
+          npm run build
         shell: bash
         env:
           TOAST_PREVENT_INSTALL: true
+      # - name: replace toast dep with local toast-node-wrapper
+      #   working-directory: starters
+      #   run: |
+      #     for D in `fd . -t d -d 1`
+      #     do
+      #       cd $D;
+      #       echo $D;
+      #       node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
+      #       cat package.json;
+      #       ls -R;
+      #       echo "\npreinstall\n"
+      #       npm install;
+      #       echo "\npost npm i\n"
+      #       npm run build;
+      #       echo "post-build"
+      #       ls -R public;
+      #       cd -;
+      #     done
+      #   shell: bash
+      #   env:
+      #     TOAST_PREVENT_INSTALL: true
       # - name: deploy
       #   working-directory: www.toast.dev
       #   if: github.event.ref == 'refs/heads/main'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: www.toast.dev
         run: |
           echo $NEW_TOAST_VERSION
-          node -e 'const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; require('fs').writeFileSync("./package.json", JSON.stringify(json, null, 2));'
+          node -e 'const fs = require('fs'); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
           cat package.json
         shell: bash
         env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -53,6 +53,7 @@ jobs:
       - name: starters — Install dependencies
         run: |
           for D in `fd starters -t d -d 1`
+          do
             cd $D;
             node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));';
             yarn;
@@ -64,6 +65,7 @@ jobs:
       - name: build starters
         run: |
           for D in `fd starters -t d -d 1`
+          do
             cd $D;
             TOAST_BINARY="$PWD/../../toast/target/debug/$BINARY_NAME" yarn build;
             cd -;

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,7 +51,7 @@ jobs:
           sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"..\/toast\/toast-node-wrapper\"/" package.json
       - name: npm install in toast.dev
         working-directory: www.toast.dev
-        run: npm ci
+        run: npm i
         env:
           TOAST_PREVENT_INSTALL: true
       - name: toast incremental

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -44,42 +44,30 @@ jobs:
       - name: Install fd
         run: |
           cargo install fd-find
-      - name: starter
+      - name: starters — create-toast
         run: |
-          npx create-toast default
-          cd default
-          node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
-          yarn
-          TOAST_BINARY="$PWD/../toast/target/debug/toast" yarn build
+          mkdir starters
+          cd starters
+          npx create-toast default default
+          npx create-toast minimal minimal
+      - name: starters — Install dependencies
+        run: |
+          for D in `fd starters -t d -d 1`
+            cd $D;
+            node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));';
+            yarn;
+            cd -;
+          end
         shell: bash
         env:
           TOAST_PREVENT_INSTALL: true
-          # TOAST_BINARY: "../toast/target/debug/toast"
-      # - name: replace toast dep with local toast-node-wrapper
-      #   working-directory: starters
-      #   run: |
-      #     for D in `fd . -t d -d 1`
-      #     do
-      #       cd $D;
-      #       echo $D;
-      #       node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
-      #       cat package.json;
-      #       ls -R;
-      #       echo "\npreinstall\n"
-      #       npm install;
-      #       echo "\npost npm i\n"
-      #       npm run build;
-      #       echo "post-build"
-      #       ls -R public;
-      #       cd -;
-      #     done
-      #   shell: bash
-      #   env:
-      #     TOAST_PREVENT_INSTALL: true
-      # - name: deploy
-      #   working-directory: www.toast.dev
-      #   if: github.event.ref == 'refs/heads/main'
-      #   env:
-      #     NETLIFY_SITE_ID: ${{ secrets.NETLIFY_WWW_SITE_ID }}
-      #     NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      #   run: npx netlify-cli deploy --dir=public --message ${{ github.event.head_commit.url }}
+      - name: build starters
+        run: |
+          for D in `fd starters -t d -d 1`
+            cd $D;
+            TOAST_BINARY="$PWD/../toast/target/debug/$BINARY_NAME" yarn build;
+            cd -;
+          end
+        shell: bash
+        env:
+          BINARY_NAME: ${{ matrix.target }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,7 +48,9 @@ jobs:
       - name: replace toast dep with local toast-node-wrapper
         working-directory: www.toast.dev
         run: |
+          echo $NEW_TOAST_VERSION
           sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"$NEW_TOAST_VERSION\"/" package.json
+          cat package.json
         env:
           NEW_TOAST_VERSION: ../toast/toast-node-wrapper
       - name: npm install in toast.dev

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,8 +46,9 @@ jobs:
         working-directory: toast
         run: cargo build
       - name: replace toast dep with local toast-node-wrapper
+        working-directory: www.toast.dev
         run: |
-          sed -i "s/^\s*\"toast\":.*$/  \"toast\":\"../toast/toast-node-wrapper\",/" package.json
+          sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"../toast/toast-node-wrapper\",/" package.json
       - name: npm install in toast.dev
         working-directory: www.toast.dev
         run: npm ci

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -50,8 +50,7 @@ jobs:
           cd default
           node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
           yarn
-          yarn breadbox --dest public/web_modules
-          TOAST_BINARY=$("$PWD/../toast/target/debug/toast") yarn build
+          TOAST_BINARY="$PWD/../toast/target/debug/toast" yarn build
         shell: bash
         env:
           TOAST_PREVENT_INSTALL: true

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: replace toast dep with local toast-node-wrapper
         working-directory: www.toast.dev
         run: |
-          sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"../toast/toast-node-wrapper\",/" package.json
+          sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"..\/toast\/toast-node-wrapper\",/" package.json
       - name: npm install in toast.dev
         working-directory: www.toast.dev
         run: npm ci

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           repository: toastdotdev/www.toast.dev
           path: www.toast.dev
+      - run: |
+          ls
+          ls ..
+          ls toast
+          ls www.toast.dev
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -54,6 +54,8 @@ jobs:
         run: |
           for D in `fd starters -t d -d 1`
           do
+            echo $D;
+            ls;
             cd $D;
             node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));';
             yarn;

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: replace toast dep with local toast-node-wrapper
         working-directory: www.toast.dev
         run: |
-          sed -i "s/^\s*\"toast\":.*(,?)$/  \"toast\": \"..\/toast\/toast-node-wrapper\"\1/" package.json
+          sed -i "s/^\s*\"toast\":.*\(,?\)$/  \"toast\": \"..\/toast\/toast-node-wrapper\"\1/" package.json
         - name: npm install in toast.dev
         working-directory: www.toast.dev
         run: npm ci

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,7 +48,9 @@ jobs:
       - name: replace toast dep with local toast-node-wrapper
         working-directory: www.toast.dev
         run: |
-          sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"..\/toast\/toast-node-wrapper\"/" package.json
+          sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"$NEW_TOAST_VERSION\"/" package.json
+        env:
+          NEW_TOAST_VERSION: ../toast/toast-node-wrapper
       - name: npm install in toast.dev
         working-directory: www.toast.dev
         run: npm i

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -58,7 +58,7 @@ jobs:
             node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));';
             yarn;
             cd -;
-          end
+          done
         shell: bash
         env:
           TOAST_PREVENT_INSTALL: true
@@ -69,7 +69,7 @@ jobs:
             cd $D;
             TOAST_BINARY="$PWD/../../toast/target/debug/$BINARY_NAME" yarn build;
             cd -;
-          end
+          done
         shell: bash
         env:
           BINARY_NAME: ${{ matrix.target }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: www.toast.dev
         run: |
           echo $NEW_TOAST_VERSION
-          node -e 'const fs = require('fs'); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
+          node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
           cat package.json
         shell: bash
         env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -54,10 +54,8 @@ jobs:
         run: |
           for D in `fd . 'starters/' -t d -d 1`
           do
-            echo $D;
-            ls;
             cd $D;
-            node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));';
+            node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));';
             yarn;
             cd -;
           done

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,35 +40,24 @@ jobs:
           override: true
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '14'
+          node-version: "14"
           check-latest: true
       - name: Run cargo build
         working-directory: toast
-        run: cargo build --release
-      - name: tar the binary
-        working-directory: toast
+        run: cargo build
+      - name: replace toast dep with local toast-node-wrapper
         run: |
-          tar -C target -cvzf ./target/${{matrix.platform}}.tar.gz release/${{matrix.target}}
-        shell: bash
+          sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"../toast/toast-node-wrapper\",/" package.json
       - name: npm install in toast.dev
         working-directory: www.toast.dev
         run: npm ci
-      - name: copy and replace toast in node_modules
-        working-directory: www.toast.dev
-        run: cp -r ./../toast/toast-node-wrapper ./node_modules/toast
-        shell: bash
-      - name: postinstall on toast.dev
-        working-directory: www.toast.dev
-        run: npm run postinstall
-      - name: npm install in toast node wrapper
-        working-directory: toast
-        run: cd toast-node-wrapper && npm install
-      - name: set the binary path and install
-        working-directory: www.toast.dev
-        run: node ./../toast/toast-node-wrapper/binary-management/installDev.js ./../toast/target/${{matrix.platform}}.tar.gz
+        env:
+          TOAST_PREVENT_INSTALL: true
       - name: toast incremental
         working-directory: www.toast.dev
         run: npm run build
+        env:
+          TOAST_BINARY: ../toast/target/debug/toast
       - name: display files
         working-directory: www.toast.dev/public
         run: ls -R

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,6 +51,7 @@ jobs:
           echo $NEW_TOAST_VERSION
           sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"$NEW_TOAST_VERSION\"/" package.json
           cat package.json
+        shell: bash
         env:
           NEW_TOAST_VERSION: ../toast/toast-node-wrapper
       - name: npm install in toast.dev

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -31,17 +31,8 @@ jobs:
           path: toast
       - uses: actions/checkout@v2
         with:
-          repository: toastdotdev/www.toast.dev
-          path: www.toast.dev
-      - run: |
-          ls
-          echo "--"
-          ls ..
-          echo "--"
-          ls toast
-          echo "--"
-          ls www.toast.dev
-          echo "--"
+          repository: toastdotdev/starters
+          path: starters
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -54,33 +45,30 @@ jobs:
       - name: Run cargo build
         working-directory: toast
         run: cargo build
-      - name: replace toast dep with local toast-node-wrapper
-        working-directory: www.toast.dev
+        - name: replace toast dep with local toast-node-wrapper
+        working-directory: starters
         run: |
-          echo $NEW_TOAST_VERSION
-          node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
-          cat package.json
+          for D in `find . -t d -d 1`
+          do
+            cd $D;
+            echo $D;
+            node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
+            cat package.json;
+            echo "preinstall"
+            npm i;
+            npm run build;
+            echo "post-build"
+            ls -R public;
+            cd -;
+          done
         shell: bash
         env:
-          NEW_TOAST_VERSION: ../toast/toast-node-wrapper
-      - name: npm install in toast.dev
-        working-directory: www.toast.dev
-        run: npm i
-        env:
-          TOAST_PREVENT_INSTALL: true
-      - name: toast incremental
-        working-directory: www.toast.dev
-        run: npm run build
-        env:
-          TOAST_BINARY: ../toast/target/debug/toast
-      - name: display files
-        working-directory: www.toast.dev/public
-        run: ls -R
-        shell: bash
-      - name: deploy
-        working-directory: www.toast.dev
-        if: github.event.ref == 'refs/heads/main'
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_WWW_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        run: npx netlify-cli deploy --dir=public --message ${{ github.event.head_commit.url }}
+          NEW_TOAST_VERSION: ../../toast/toast-node-wrapper
+          TOAST_BINARY: ../../toast/target/debug/toast
+      # - name: deploy
+      #   working-directory: www.toast.dev
+      #   if: github.event.ref == 'refs/heads/main'
+      #   env:
+      #     NETLIFY_SITE_ID: ${{ secrets.NETLIFY_WWW_SITE_ID }}
+      #     NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      #   run: npx netlify-cli deploy --dir=public --message ${{ github.event.head_commit.url }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           for D in `fd starters -t d -d 1`
             cd $D;
-            TOAST_BINARY="$PWD/../toast/target/debug/$BINARY_NAME" yarn build;
+            TOAST_BINARY="$PWD/../../toast/target/debug/$BINARY_NAME" yarn build;
             cd -;
           end
         shell: bash

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -50,8 +50,6 @@ jobs:
           cd default
           node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; delete json.scripts.postinstall; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
           yarn
-          ls -R node_modules/toast
-          ls -R node_modules/preact
           yarn breadbox --dest public/web_modules
           yarn build
         shell: bash

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: replace toast dep with local toast-node-wrapper
         working-directory: starters
         run: |
-          for D in `find . -t d -d 1`
+          for D in `find . -d 1`
           do
             cd $D;
             echo $D;

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -47,7 +47,7 @@ jobs:
         run: cargo build
       - name: Install fd
         run: |
-          sudo apt install fd-find
+          cargo install fd-find
       - name: replace toast dep with local toast-node-wrapper
         working-directory: starters
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,8 +48,8 @@ jobs:
       - name: replace toast dep with local toast-node-wrapper
         working-directory: www.toast.dev
         run: |
-          sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"..\/toast\/toast-node-wrapper\",/" package.json
-      - name: npm install in toast.dev
+          sed -i "s/^\s*\"toast\":.*(,?)$/  \"toast\": \"..\/toast\/toast-node-wrapper\"\1/" package.json
+        - name: npm install in toast.dev
         working-directory: www.toast.dev
         run: npm ci
         env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -38,23 +38,24 @@ jobs:
         with:
           node-version: "14"
           check-latest: true
-      # - name: Run cargo build
-      #   working-directory: toast
-      #   run: cargo build
-      # - name: Install fd
-      #   run: |
-      #     cargo install fd-find
+      - name: Run cargo build
+        working-directory: toast
+        run: cargo build
+      - name: Install fd
+        run: |
+          cargo install fd-find
       - name: starter
         run: |
           npx create-toast default
           cd default
-          node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; delete json.scripts.postinstall; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
+          node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
           yarn
           yarn breadbox --dest public/web_modules
-          yarn build
+          TOAST_BINARY=$("$PWD/../toast/target/debug/toast") yarn build
         shell: bash
         env:
           TOAST_PREVENT_INSTALL: true
+          # TOAST_BINARY: "../toast/target/debug/toast"
       # - name: replace toast dep with local toast-node-wrapper
       #   working-directory: starters
       #   run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -35,9 +35,13 @@ jobs:
           path: www.toast.dev
       - run: |
           ls
+          echo "--"
           ls ..
+          echo "--"
           ls toast
+          echo "--"
           ls www.toast.dev
+          echo "--"
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: www.toast.dev
         run: |
           echo $NEW_TOAST_VERSION
-          sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"$NEW_TOAST_VERSION\"/" package.json
+          node -e 'const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; require('fs').writeFileSync("./package.json", JSON.stringify(json, null, 2));'
           cat package.json
         shell: bash
         env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -52,7 +52,7 @@ jobs:
           do
             cd $D;
             echo $D;
-            node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
+            node -e 'const fs = require("fs"); const json = require("./package.json"); json.dependencies.toast = "file:../../toast/toast-node-wrapper"; fs.writeFileSync("./package.json", JSON.stringify(json, null, 2));'
             cat package.json;
             echo "preinstall"
             npm i;
@@ -63,7 +63,6 @@ jobs:
           done
         shell: bash
         env:
-          NEW_TOAST_VERSION: ../../toast/toast-node-wrapper
           TOAST_BINARY: ../../toast/target/debug/toast
       # - name: deploy
       #   working-directory: www.toast.dev

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -47,7 +47,7 @@ jobs:
         run: cargo build
       - name: replace toast dep with local toast-node-wrapper
         run: |
-          sed -i "s/^\s*\"toast\":.*$/  \"toast\": \"../toast/toast-node-wrapper\",/" package.json
+          sed -i "s/^\s*\"toast\":.*$/  \"toast\":\"../toast/toast-node-wrapper\",/" package.json
       - name: npm install in toast.dev
         working-directory: www.toast.dev
         run: npm ci

--- a/toast-node-wrapper/binary-management/binary.js
+++ b/toast-node-wrapper/binary-management/binary.js
@@ -98,10 +98,12 @@ export function uninstall(
   }
 }
 
-const getBinaryUrlForPlatform = ({
-  binaryHash = binaryHash,
-  platform = getPlatform(),
-}) => {
+const getBinaryUrlForPlatform = (
+  { binaryHash = binaryHash, platform = getPlatform() } = {
+    binaryHash: binaryHash,
+    platform: getPlatform(),
+  }
+) => {
   // the url for this binary is constructed from values in `package.json`
   // https://github.com/toastdotdev/toast/releases/download/v1.0.0/toast-example-v1.0.0-x86_64-apple-darwin.tar.gz
   // const url = `${repository.url}/releases/download/v${version}/${name}-v${version}-${platform}.tar.gz`;

--- a/toast-node-wrapper/binary-management/binary.js
+++ b/toast-node-wrapper/binary-management/binary.js
@@ -98,24 +98,19 @@ export function uninstall(
   }
 }
 
-const getBinaryUrlForPlatform = (
-  { binaryHash = binaryHash, platform = getPlatform() } = {
-    binaryHash: binaryHash,
-    platform: getPlatform(),
-  }
-) => {
+const getBinaryUrlForPlatform = ({ binaryHash: bHash, platform } = {}) => {
+  let hash = bHash || binaryHash;
+  let plat = platform || getPlatform();
   // the url for this binary is constructed from values in `package.json`
   // https://github.com/toastdotdev/toast/releases/download/v1.0.0/toast-example-v1.0.0-x86_64-apple-darwin.tar.gz
   // const url = `${repository.url}/releases/download/v${version}/${name}-v${version}-${platform}.tar.gz`;
-  return `https://github.com/toastdotdev/toast/releases/download/binaries-ci-${binaryHash}/${platform}.tar.gz`;
+  return `https://github.com/toastdotdev/toast/releases/download/binaries-ci-${hash}/${plat}.tar.gz`;
 };
 
-export async function installFromUrl(
-  { url = getBinaryUrlForPlatform(), binaryDirectory = _binaryDirectory } = {
-    url: getBinaryUrlForPlatform(),
-    binaryDirectory: _binaryDirectory,
-  }
-) {
+export async function installFromUrl({ url: u, binaryDirectory: bDir } = {}) {
+  let binaryDirectory = bDir || _binaryDirectory;
+  const url = u || getBinaryUrlForPlatform();
+
   if (existsSync(binaryDirectory)) {
     rimraf.sync(binaryDirectory);
   }

--- a/toast-node-wrapper/binary-management/binary.js
+++ b/toast-node-wrapper/binary-management/binary.js
@@ -18,156 +18,14 @@ const error = (msg, e) => {
   process.exit(1);
 };
 
-// this was originally a soft fork of binary-install
-// https://github.com/cloudflare/binary-install
-// we need to add versioning and local fetching
-class Binary {
-  constructor(url, data) {
-    if (typeof url !== "string") {
-      errors.push("url must be a string");
-    } else {
-      try {
-        new URL(url);
-      } catch (e) {
-        errors.push(e);
-      }
-    }
-    let errors = [];
-    if (data.name && typeof data.name !== "string") {
-      errors.push("name must be a string");
-    }
-    if (data.installDirectory && typeof data.installDirectory !== "string") {
-      errors.push("installDirectory must be a string");
-    }
-    if (!data.installDirectory && !data.name) {
-      errors.push("You must specify either name or installDirectory");
-    }
-    if (errors.length > 0) {
-      let errorMsg = "Your Binary constructor is invalid:";
-      errors.forEach((error) => {
-        errorMsg += error;
-      });
-      error(errorMsg);
-    }
-    this.url = url;
-    this.name = data.name || -1;
-    this.installDirectory = data.installDirectory || envPaths(this.name).config;
-    this.binaryDirectory = -1;
-    this.binaryPath = -1;
-  }
-
-  _getInstallDirectory() {
-    if (!existsSync(this.installDirectory)) {
-      mkdirSync(this.installDirectory, { recursive: true });
-    }
-    return this.installDirectory;
-  }
-
-  _getBinaryDirectory() {
-    const installDirectory = this._getInstallDirectory();
-    const binaryDirectory = join(this.installDirectory, "bin");
-    if (existsSync(binaryDirectory)) {
-      this.binaryDirectory = binaryDirectory;
-    } else {
-      error(`You have not installed ${this.name ? this.name : "this package"}`);
-    }
-    return this.binaryDirectory;
-  }
-
-  _getBinaryPath() {
-    if (this.binaryPath === -1) {
-      const binaryDirectory = this._getBinaryDirectory();
-      this.binaryPath = join(binaryDirectory, this.name);
-    }
-
-    return this.binaryPath;
-  }
-
-  async install() {
-    if (binaryHash === "<binaryhash>" && !devBinaryTar) return;
-
-    const dir = this._getInstallDirectory();
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
-    }
-
-    this.binaryDirectory = join(dir, "bin");
-
-    if (existsSync(this.binaryDirectory)) {
-      rimraf.sync(this.binaryDirectory);
-    }
-
-    mkdirSync(this.binaryDirectory, { recursive: true });
-
-    if (!this.url.startsWith("http")) {
-      console.log(`Extracting release from ${this.url}`);
-      tar
-        .x({ file: this.url, strip: 1, C: this.binaryDirectory })
-        .then(() => {
-          console.log(
-            `${this.name ? this.name : "Your package"} has been installed!`
-          );
-        })
-        .catch((e) => {
-          error(`Error extracting release: ${e.message}`, e);
-        });
-    } else {
-      console.log(`Downloading release from ${this.url}`);
-
-      return axios({ url: this.url, responseType: "stream" })
-        .then((res) => {
-          res.data.pipe(tar.x({ strip: 1, C: this.binaryDirectory }));
-        })
-        .then(() => {
-          console.log(
-            `${this.name ? this.name : "Your package"} has been installed!`
-          );
-        })
-        .catch((e) => {
-          error("Error fetching release", e.message);
-        });
-    }
-  }
-
-  uninstall() {
-    if (existsSync(this._getInstallDirectory())) {
-      rimraf.sync(this.installDirectory);
-      console.log(
-        `${this.name ? this.name : "Your package"} has been uninstalled`
-      );
-    }
-  }
-
-  run() {
-    const binaryPath = this._getBinaryPath();
-    const [, , ...args] = process.argv;
-
-    const options = { cwd: process.cwd(), stdio: "inherit" };
-
-    const result = spawnSync(binaryPath, args, options);
-
-    if (result.error) {
-      console.error(result.error);
-      process.exit(1);
-    }
-
-    process.exit(result.status);
-  }
-}
-
 const packageJSON = path.join(
   path.dirname(path.dirname(fileURLToPath(import.meta.url))),
   "package.json"
 );
 
-const {
-  version,
-  name,
-  repository,
-  binaryHash,
-  devBinaryTar,
-  ...etc
-} = JSON.parse(readFileSync(packageJSON));
+const { version, name, repository, binaryHash, ...etc } = JSON.parse(
+  readFileSync(packageJSON)
+);
 
 const supportedPlatforms = [
   {
@@ -187,7 +45,7 @@ const supportedPlatforms = [
   },
 ];
 
-const getPlatform = () => {
+export const getPlatform = () => {
   const type = os.type();
   const architecture = os.arch();
 
@@ -208,34 +66,100 @@ const getPlatform = () => {
   );
 };
 
-const getBinary = () => {
-  const platform = getPlatform();
+///
+
+const _installDirectory = envPaths(name).config;
+const _binaryDirectory = join(_installDirectory, version, "bin");
+const _binaryPath = join(_binaryDirectory, name);
+
+// static information that doesn't change once the package is run.
+export const meta = {
+  installDir: _installDirectory,
+  binaryDir: _binaryDirectory,
+  binaryPath: _binaryPath,
+  version,
+  name,
+  repository,
+  binaryHash,
+};
+
+// users never really call this because removal isn't usually "nicely done"
+// it's usually "rm -rf" or something
+export function uninstall(
+  { installDirectory = _installDirectory } = {
+    installDirectory: _installDirectory,
+  }
+) {
+  if (existsSync(installDirectory)) {
+    rimraf.sync(installDirectory);
+    console.log(
+      `${this.name ? this.name : "Your package"} has been uninstalled`
+    );
+  }
+}
+
+const getBinaryUrlForPlatform = ({
+  binaryHash = binaryHash,
+  platform = getPlatform(),
+}) => {
   // the url for this binary is constructed from values in `package.json`
   // https://github.com/toastdotdev/toast/releases/download/v1.0.0/toast-example-v1.0.0-x86_64-apple-darwin.tar.gz
   // const url = `${repository.url}/releases/download/v${version}/${name}-v${version}-${platform}.tar.gz`;
-  const url = devBinaryTar
-    ? devBinaryTar
-    : `https://github.com/toastdotdev/toast/releases/download/binaries-ci-${binaryHash}/${platform}.tar.gz`;
-  return new Binary(url, { name: "toast" });
+  return `https://github.com/toastdotdev/toast/releases/download/binaries-ci-${binaryHash}/${platform}.tar.gz`;
 };
 
-export const run = () => {
-  const binary = getBinary();
-  binary.run();
-};
+export async function installFromUrl(
+  { url = getBinaryUrlForPlatform(), binaryDirectory = _binaryDirectory } = {
+    url: getBinaryUrlForPlatform(),
+    binaryDirectory: _binaryDirectory,
+  }
+) {
+  if (existsSync(binaryDirectory)) {
+    rimraf.sync(binaryDirectory);
+  }
 
-export const setLocalBinaryPath = (localPath) => {
-  let packageJSONContent = JSON.parse(readFileSync(packageJSON));
-  packageJSONContent.devBinaryTar = path.resolve(localPath);
-  writeFileSync(packageJSON, JSON.stringify(packageJSONContent, null, 2));
-};
+  mkdirSync(binaryDirectory, { recursive: true });
 
-export const install = () => {
-  const binary = getBinary();
-  binary.install();
-};
+  console.log(`Downloading release from ${url}`);
 
-export const uninstall = () => {
-  const binary = getBinary();
-  binary.uninstall();
-};
+  return axios({ url, responseType: "stream" })
+    .then((res) => {
+      res.data.pipe(tar.x({ strip: 1, C: binaryDirectory }));
+    })
+    .then(() => {
+      console.log(
+        `${
+          this.name ? this.name : "Your package"
+        } has been installed to ${binaryDirectory}!`
+      );
+    })
+    .catch((e) => {
+      error("Error fetching release", e.message);
+    });
+}
+
+export function run(
+  { binaryPath = _binaryPath } = { binaryPath: _binaryPath }
+) {
+  const [, , ...args] = process.argv;
+
+  const options = { cwd: process.cwd(), stdio: "inherit" };
+
+  const result = spawnSync(binaryPath, args, options);
+
+  if (result.error) {
+    console.error(result.error);
+    process.exit(1);
+  }
+
+  process.exit(result.status);
+}
+
+export function getCurrentPlatformMeta() {
+  const platform = getPlatform();
+  const url = getBinaryUrlForPlatform({ platform, binaryHash });
+  return {
+    ...meta,
+    remoteBinaryUrl: url,
+  };
+}

--- a/toast-node-wrapper/binary-management/install.js
+++ b/toast-node-wrapper/binary-management/install.js
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
-import { install } from "./binary.js";
+import { installFromUrl } from "./binary.js";
 
-install();
+if (process.env.TOAST_PREVENT_INSTALL) {
+  console.log(
+    "Toast binary install from url prevented by env var TOAST_PREVENT_INSTALL"
+  );
+} else {
+  installFromUrl({});
+}

--- a/toast-node-wrapper/binary-management/installDev.js
+++ b/toast-node-wrapper/binary-management/installDev.js
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-
-import { setLocalBinaryPath, install } from "./binary.js";
-
-setLocalBinaryPath(process.argv[2]);
-install();

--- a/toast-node-wrapper/binary-management/run.js
+++ b/toast-node-wrapper/binary-management/run.js
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
-import { run } from "./binary.js";
+import { run, meta } from "./binary.js";
 
-run();
+if (process.env.TOAST_BINARY) {
+  console.log(
+    `Running ${meta.name} with overridden binary path: ${process.env.TOAST_BINARY}`
+  );
+  run({ binaryPath: process.env.TOAST_BINARY });
+} else {
+  run({});
+}


### PR DESCRIPTION
* simplify binary handling
* split out functions for easier testability and dev/prod behavior
* add version to binary dir path

enables disallowing the installation of the toast binary from a url with `TOAST_PREVENT_INSTALL` and specifying the binary location with `TOAST_BINARY`

```shell
TOAST_PREVENT_INSTALL=true TOAST_BINARY=/Users/chris/github/toastdotdev/toast/target/debug/toast toast incremental .
```