### PR TITLE
feat: support noscript in static output

### DIFF
--- a/toast-node-wrapper/src/page-renderer-pre.mjs
+++ b/toast-node-wrapper/src/page-renderer-pre.mjs
@@ -19,6 +19,7 @@ window.dataPath = ${dataPath && `"${dataPath}"`};
   ${helmet.title.toString()}
   ${helmet.meta.toString()}
   ${helmet.link.toString()}
+  ${helmet.noscript.toString()}
   </head>
   <body ${helmet.bodyAttributes.toString()}>
     <div id="toast-page-section">${appHtml}</div>


### PR DESCRIPTION
enables support for `<noscript>`, which I ended up needing to do some JS-specific styling