### PR TITLE
Add documentation links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-![toast header](./imgs/toast-header.png)
+[![toast header](./imgs/toast-header.png)][docs]
+
+🤝 [Interested in contributing?][contributing]
+
+
+[docs]: https://toast.dev
+[contributing]: CONTRIBUTING.md


### PR DESCRIPTION
I was expecting the big banner to link me to a place where I could read more about this, so I think this will help people learn about toast and how great it is.