### PR TITLE
Add support for <script> elements in Helmet

### DIFF
--- a/toast-node-wrapper/src/page-renderer-pre.mjs
+++ b/toast-node-wrapper/src/page-renderer-pre.mjs
@@ -19,6 +19,7 @@ window.dataPath = ${dataPath && `"${dataPath}"`};
   ${helmet.title.toString()}
   ${helmet.meta.toString()}
   ${helmet.link.toString()}
+  ${helmet.script.toString()}
   ${helmet.noscript.toString()}
   </head>
   <body ${helmet.bodyAttributes.toString()}>


### PR DESCRIPTION
Adds the ability to pre-render script tags on toast sites.