### PR TITLE
Add missing quotes to example code

### DIFF
--- a/toast-node-wrapper/toast-source-data.mjs
+++ b/toast-node-wrapper/toast-source-data.mjs
@@ -42,7 +42,7 @@ It should be an object with a mode of "filepath" or "source":
 const page = {
   component: {
     mode: "source",
-    value: \`import { h } from preact;
+    value: \`import { h } from "preact";
 
 export default props => <div>
   <h1>Some Code</h1>


### PR DESCRIPTION
Using this example will result in an error:

```
node_modules/.bin/toast incremental .
▪▪▪ [0s] 1 pages created
⠁
error: Unexpected token `preact`. Expected a string literal
 --> </>:1:19
  |
1 | import { h } from preact;
  |                   ^^^^^^

The application panicked (crashed).
Message:  called `Result::unwrap()` on an `Err` value: failed to parse module
Location: toast/src/swc_ops.rs:52

Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

Adding the quotes fixes it.