### PR TITLE
Add preact/jsx-runtime alias

### DIFF
--- a/toast-node-wrapper/src/loader.mjs
+++ b/toast-node-wrapper/src/loader.mjs
@@ -2,6 +2,7 @@ import "./module-aliases.mjs";
 const moduleAliases = {
   react: "preact/compat",
   "react-dom": "preact/compat",
+  "react/jsx-runtime": "preact/jsx-runtime",
 };
 
 export const resolve = (specifier, parentModuleURL, defaultResolve) => {

--- a/toast-node-wrapper/src/module-aliases.mjs
+++ b/toast-node-wrapper/src/module-aliases.mjs
@@ -3,5 +3,6 @@ import moduleAlias from "module-alias";
 moduleAlias.addAliases({
   react: "preact/compat",
   "react-dom": "preact/compat",
+  "react/jsx-runtime": "preact/jsx-runtime",
   //   'create-react-class': path.resolve(__dirname, './create-preact-class')
 });


### PR DESCRIPTION
Allow for `automatic` jsx transform (`react/jsx-runtime`) react component libraries to alias to the `preact/jsx-runtime`.

```js
export function Hello() {
	return <div>Hello</div>;
}
```

compiles to:

```js
import { jsx } from "react/jsx-runtime";
export function Hello() {
  return /*#__PURE__*/jsx ("div", {
    children: "Hello"
  });
}
```

The alternative to the `automatic`  is `classic` which uses `React.createElement` and this is currently handled with the `react: "preact/compat"` alias.

compiles to:

```js
import React from "react";
export function Hello() {
  return /*#__PURE__*/React.createElement("div", null, "Hello");
}
```